### PR TITLE
Setup Transparent Publishing

### DIFF
--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -19,7 +19,7 @@ jobs:
       env:
         NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
       with:
-        NPM_PUBLISH: npm run bin/publish
+        NPM_PUBLISH: npm run pack:publish
     - name: Post Instructions Comment
       uses: thefrontside/actions/post-npm-usage-instructions-comment@master
       env:

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -15,11 +15,10 @@ jobs:
     - name: Write NPM Snapshot Version
       uses: thefrontside/actions/write-npm-snapshot-version@master
     - name: NPM Publish Commit
-      uses: minkimcello/actions/npm-publish-branch-preview@mk/publish-pr-preview
+      uses: thefrontside/actions/npm-publish-branch-preview@master
       env:
         NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
     - name: Post Instructions Comment
       uses: thefrontside/actions/post-npm-usage-instructions-comment@master
       env:
-        #GITHUB_TOKEN: ${{ secrets.GITHUB_POST_COMMENT_TOKEN }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_POST_COMMENT_TOKEN }}

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -1,0 +1,25 @@
+name: Publish Preview
+
+on:
+  pull_request:
+    branches:
+      - master
+      - release-*
+
+jobs:
+  preview: 
+    name: Publish Preview Package
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Write NPM Snapshot Version
+      uses: thefrontside/actions/write-npm-snapshot-version@master
+    - name: NPM Publish Commit
+      uses: minkimcello/actions/npm-publish-branch-preview@mk/publish-pr-preview
+      env:
+        NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+    - name: Post Instructions Comment
+      uses: thefrontside/actions/post-npm-usage-instructions-comment@master
+      env:
+        #GITHUB_TOKEN: ${{ secrets.GITHUB_POST_COMMENT_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Write NPM Snapshot Version
       uses: thefrontside/actions/write-npm-snapshot-version@master
     - name: NPM Publish Commit
-      uses: minkimcello/actions/npm-publish-branch-preview@mk/extending-publishing
+      uses: thefrontside/actions/npm-publish-branch-preview@master
       env:
         NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
       with:
@@ -23,4 +23,4 @@ jobs:
     - name: Post Instructions Comment
       uses: thefrontside/actions/post-npm-usage-instructions-comment@master
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_POST_COMMENT_TOKEN }}

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -19,7 +19,7 @@ jobs:
       env:
         NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
       with:
-        NPM_PUBLISH: bin/publish
+        NPM_PUBLISH: npm run bin/publish
     - name: Post Instructions Comment
       uses: thefrontside/actions/post-npm-usage-instructions-comment@master
       env:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,19 @@
+name: Publish Release
+
+on:
+  push:
+    branches:
+      - master
+      - release-*
+
+jobs:
+  publish:
+    name: Synchronize with NPM
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Tag and Publish
+      uses: thefrontside/actions/synchronize-with-npm@master
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -18,4 +18,4 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
       with:
-        NPM_PUBLISH: bin/publish
+        NPM_PUBLISH: npm run bin/publish

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -18,4 +18,4 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
       with:
-        NPM_PUBLISH: npm run bin/publish
+        NPM_PUBLISH: npm run pack:publish

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Tag and Publish
-      uses: minkimcello/actions/synchronize-with-npm@mk/extending-publishing
+      uses: thefrontside/actions/synchronize-with-npm@master
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/synchronize-npm-tags.yml
+++ b/.github/workflows/synchronize-npm-tags.yml
@@ -1,0 +1,14 @@
+name: Synchronize NPM Tags
+
+on:
+  delete
+
+jobs:
+  clean:
+    name: Synchronize NPM Tags
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: minkimcello/actions/synchronize-npm-tags@mk/publish-pr-preview
+      env:
+        NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/synchronize-npm-tags.yml
+++ b/.github/workflows/synchronize-npm-tags.yml
@@ -9,6 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - uses: minkimcello/actions/synchronize-npm-tags@mk/publish-pr-preview
+    - uses: thefrontside/actions/synchronize-npm-tags@master
       env:
         NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "effection",
+  "name": "@minkimcello/effection",
   "version": "0.1.0",
   "description": "Effortlessly composable structured concurrency primitive for JavaScript",
   "repository": "http://github.com/cowboyd/effection.js",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "mocha --recursive -r ./tests/setup tests",
     "test-types": "mocha -r ts-node/register types/*.test.ts",
     "lint": "eslint ./",
-    "bin/publish": "pack build && cd pkg && npm publish $*"
+    "pack:publish": "pack build && cd pkg && npm publish $*"
   },
   "devDependencies": {
     "nyc": "13.1.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@minkimcello/effection",
+  "name": "effection",
   "version": "0.1.0",
   "description": "Effortlessly composable structured concurrency primitive for JavaScript",
   "repository": "http://github.com/cowboyd/effection.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@minkimcello/effection",
-  "version": "0.1.1",
+  "name": "effection",
+  "version": "0.1.0",
   "description": "Effortlessly composable structured concurrency primitive for JavaScript",
   "repository": "http://github.com/cowboyd/effection.js",
   "author": "Charles Lowell <cowboyd@frontside.io>",


### PR DESCRIPTION
## Motivation
The purpose of this PR is to setup workflows for Transparent Publishing using [`thefrontside/actions`](https://github.com/thefrontside/actions). A similar setup is already up and running on [`microstates/microstates.js`](https://github.com/microstates/microstates.js).

Please see TODOs below for the steps required before merging this PR.

## Approach
### publish-preview
This workflow triggers on pull requests created against `master` or `release-*`:
- Update package version with SHA
- Publish to NPM with the branch name as tag
- Generate comment on PR with instructions on how to use package

[Test Run from `minkimcello/effection`](https://github.com/minkimcello/effection.js/commit/78c7b255897d46d1bdf53663cab5ff0559654520/checks?check_suite_id=266515620)

### publish-release
This workflow triggers on push/commits to `master`and `release-*`:   
- Verify NPM_AUTH_TOKEN is accessible
- Verify the package version has not already been published
- Push git tags
- Publish to NPM

[Test Run from `minkimcello/effection`](https://github.com/minkimcello/effection.js/commit/2e1edb4be5b58b9420ec7f05236546d01d62e92a/checks?check_suite_id=266520894)

### synchronize-npm-tags
This workflow runs any time a branch is deleted:
- Removes all tags (with the exception of `latest`) from NPM that do not correspond to: 
  - existing github branches
  - argument passed in from the workflow configuration.

[Test Run from `minkimcello/effection`](https://github.com/minkimcello/effection.js/commit/1964ed5c75170c751a80211472bb86055ebd5ee7/checks?check_suite_id=266528015)

## TODOs
- [x] Add `NPM_AUTH_TOKEN` to secrets
- [x] Add `GITHUB_POST_COMMENT_TOKEN` to secrets
- [x] Approve [#19 from `thefrontside/actions`](https://github.com/thefrontside/actions/pull/19)
- [x] :heavy_exclamation_mark: Approve [#20 from `thefrontside/actions`](https://github.com/thefrontside/actions/pull/20)

## Test for Pika
- [Preview Build/Publishing on `minkimcello/effections`](https://github.com/minkimcello/effection.js/commit/81e45cb65f5ca1c206c6a60b2dee17df77363509/checks?check_suite_id=268007572)
- [Release Build/Publishing on `minkimcello/effections`](https://github.com/minkimcello/effection.js/commit/f220d0992ebadc5d989a52c48d60d9dfb263b97f/checks?check_suite_id=268019852)

And when installed as a package:
<img width="616" alt="Screen Shot 2019-10-16 at 2 58 53 PM" src="https://user-images.githubusercontent.com/29791650/66951405-4a743a80-f028-11e9-8ef5-1b4796eeabc7.png">