### PR TITLE
Add Typescript typings

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,8 @@
 /dist
 /pkg
+/scratchpad
 /node_modules
 /benchmarks
 /README
+/**/*.d.ts
+/tests/typescript/*.ts

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,16 @@
 declare module "effection" {
+  export type Operation = SequenceFn | Promise<any> | Controller | undefined;
+  export type SequenceFn = (this: Execution, ...args: any[]) => Sequence;
+  export type Sequence = Generator<Operation, any, any>;
+  export type Controller = (execution: Execution) => void | (() => void);
 
-  export const timeout: (duration: number) => any;
+  export interface Execution<T = any> {
+    resume(result: T): void;
+    throw(error: Error): void;
+  }
+
+  export function execute<T>(operation: Operation): Execution<T>;
+  export function call(operation: Operation, ...args: any[]): Operation;
+
+  export function timeout(durationMillis: number): Operation;
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "author": "Charles Lowell <cowboyd@frontside.io>",
   "license": "MIT",
   "private": false,
+  "types": "./index.d.ts",
   "scripts": {
     "coverage": "nyc --reporter=html --reporter=text npm run test",
     "coveralls": "nyc report --reporter=text-lcov | coveralls",
@@ -14,7 +15,6 @@
     "publish": "pack publish",
     "prepublishOnly": "yarn test && yarn build",
     "test": "mocha --recursive -r ./tests/setup tests",
-    "test-types": "mocha -r ts-node/register types/*.test.ts",
     "lint": "eslint ./",
     "pack:publish": "pack build && cd pkg && npm publish $*"
   },
@@ -37,7 +37,7 @@
     "mocha": "6.1.4",
     "ts-expect": "^1.1.0",
     "ts-node": "^8.1.0",
-    "typescript": "^3.4.5"
+    "typescript": "^3.6.4"
   },
   "nyc": {
     "exclude": [

--- a/tests/typescript.test.js
+++ b/tests/typescript.test.js
@@ -1,0 +1,27 @@
+/* global describe, it */
+
+import expect from 'expect';
+import './typescript/matcher';
+
+describe("Typescript types", function() {
+  //Typescript compilation is slow!
+  this.timeout(5000);
+
+  it("can import types from effection", () => {
+    expect('imports.ts').toCompile();
+  });
+  it('can execute anything that is a valid operation', () => {
+    expect('execute.good.ts').toCompile();
+  });
+  it('cannot execute things that are not operations', () => {
+    expect('execute.bad.ts').not.toCompile();
+  });
+
+  it('can compile sequences that yield valid operations', () => {
+    expect('sequence.good.ts').toCompile();
+  });
+
+  it('cannot compile sequences that yield invalid operations', () => {
+    expect('sequence.bad.ts').not.toCompile();
+  });
+});

--- a/tests/typescript/execute.bad.ts
+++ b/tests/typescript/execute.bad.ts
@@ -1,0 +1,3 @@
+import { Execution, Sequence, execute } from 'effection';
+
+execute(5);

--- a/tests/typescript/execute.good.ts
+++ b/tests/typescript/execute.good.ts
@@ -1,0 +1,15 @@
+import { Execution, Sequence, execute } from 'effection';
+
+function* operation(): Sequence {}
+
+let execution: Execution;
+
+execution = execute(operation);
+
+execution = execute(Promise.resolve("hello world"));
+
+execution = execute(function*() {});
+
+execution = execute(undefined);
+
+execution = execute((execution: Execution<void>) => execution.resume());

--- a/tests/typescript/imports.ts
+++ b/tests/typescript/imports.ts
@@ -1,0 +1,7 @@
+import {
+  Operation,
+  Sequence,
+  Execution,
+  execute,
+  timeout
+} from 'effection';

--- a/tests/typescript/matcher.js
+++ b/tests/typescript/matcher.js
@@ -1,0 +1,54 @@
+import expect from 'expect';
+import path from 'path';
+
+import { createProgram, getPreEmitDiagnostics } from 'typescript';
+
+expect.extend({
+  toCompile(received) {
+    let diagnostics = compile(received);
+    let pass = diagnostics.length == 0;
+    if (pass) {
+      return {
+        pass,
+        message: () =>
+          `expected '${received}' to compile with errors, but it compiled cleanly`
+      };
+    } else {
+      return {
+        pass,
+        message: () =>
+          `expected '${received}' to compile without errors, but it failed:
+
+${formatTypescriptDiagnostics(diagnostics)}`
+      };
+    }
+  }
+});
+
+function formatTypescriptDiagnostic(diagnostic) {
+  let { file, messageText } = diagnostic;
+  if (file) {
+
+    let { line, character } =
+        file.getLineAndCharacterOfPosition(diagnostic.start);
+
+    let { originalFileName } = file;
+    return `${originalFileName}:${line + 1}:${character} ${messageText}`;
+  } else {
+    return messageText;
+  }
+}
+
+function formatTypescriptDiagnostics(diagnostics) {
+  return diagnostics.map(formatTypescriptDiagnostic).join("\n");
+}
+
+
+function compile(fileName) {
+  let location = path.join("tests", "typescript", fileName);
+  let program = createProgram(["index.d.ts", location], {
+    noEmit: true
+  });
+  let emitResult = program.emit();
+  return getPreEmitDiagnostics(program).concat(emitResult.diagnostics);
+}

--- a/tests/typescript/sequence.bad.ts
+++ b/tests/typescript/sequence.bad.ts
@@ -1,0 +1,9 @@
+import { Sequence } from 'effection';
+
+function* sequence(): Sequence {
+  // a sequence can only yield valid operations
+  // but 5 is not a valid operation
+  // therefore `function*() { yield 5 }` is not
+  // a valid operation.
+  yield function*() { yield 5; };
+}

--- a/tests/typescript/sequence.good.ts
+++ b/tests/typescript/sequence.good.ts
@@ -1,0 +1,12 @@
+import { Sequence } from 'effection';
+
+function* sequence(): Sequence {
+  //bare generator function is ok
+  let value: number = yield function*() { return 5; }
+
+  // you can always yield undefined;
+  yield;
+
+  // other Operation also ok.
+  yield sequence
+}


### PR DESCRIPTION
## Motivation

Typescript provides a very nice level of auto-documenation and discoverability to its users, especially for a strange new api like the one provided by `effection`. By definining types for effection functions, this will let us bring it easily to the typescript community and allow it to clear the bar set by that community. We want to make sure that as the affection library evolves, its associated types also evolve.

## Approach

Rather than implement types at the `DefinitelyTyped` repository where they could conceivably get out of sync with this package, instead this adds an `index.d.ts` directly to this project that will ship with every NPM package.

To ensure that the typescript typings work, the typescript.test.js loads a set of files and then asserts that they either typecheck or that they dont.