### PR TITLE
Cleanup package json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,6 @@
     "coverage": "nyc --reporter=html --reporter=text npm run test",
     "coveralls": "nyc report --reporter=text-lcov | coveralls",
     "build": "pack build",
-    "prepare": "yarn build",
-    "publish": "pack publish",
-    "prepublishOnly": "yarn test && yarn build",
     "test": "mocha --recursive -r ./tests/setup tests",
     "lint": "eslint ./",
     "pack:publish": "pack build && cd pkg && npm publish $*"
@@ -35,8 +32,6 @@
     "jest-mock": "^24.8.0",
     "mocha": "6.1.4",
     "nyc": "~14.1.1",
-    "ts-expect": "^1.1.0",
-    "ts-node": "^8.1.0",
     "typescript": "^3.6.4"
   },
   "nyc": {


### PR DESCRIPTION
There's some accumulated cruft inside `package.json`.

- we don't need a bunch of custom publish scripts, only `pack:publish`
which will be invoked via github action.

- We don't need to test types using `ts-node` anymore since we're
  instantiating the TypeScript compiler directly.

- [x] In order to avoid conflicts, please merge #10 first.