### PR TITLE
Make `fork()` a simple function

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,11 +152,11 @@ part of your main process. To do this, you would use the `fork` method
 on the execution:
 
 ``` javascript
-import { execute } from 'effection';
+import { execute, fork } from 'effection';
 
 execute(function*() {
-  this.fork(createFileServer);
-  this.fork(createHttpServer);
+  fork(createFileServer);
+  fork(createHttpServer);
 });
 ```
 

--- a/examples/async.js
+++ b/examples/async.js
@@ -1,14 +1,14 @@
 /* eslint no-console: 0 */
 /* eslint require-yield: 0 */
-import { execute, timeout } from '../src/index';
+import { execute, fork, timeout } from '../src/index';
 
 
 /**
  * Fires up some random servers
  */
 execute(interruptable(function*() {
-  this.fork(randoLogger('Bob'));
-  this.fork(randoLogger('Alice'));
+  fork(randoLogger('Bob'));
+  fork(randoLogger('Alice'));
 
   console.log('Up and running with random number servers Bob and Alice....');
 }));

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,6 +11,7 @@ declare module "effection" {
 
   export function execute<T>(operation: Operation): Execution<T>;
   export function call(operation: Operation, ...args: any[]): Operation;
+  export function fork<T>(operation: Operation): Execution<T>;
 
   export function timeout(durationMillis: number): Operation;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
 export { execute } from './execute';
 export { timeout } from './timeout';
-export { call } from './execution';
+export { fork, call } from './execution';
 export { promiseOf } from './promise-of';

--- a/tests/async.test.js
+++ b/tests/async.test.js
@@ -4,7 +4,7 @@
 
 import expect from 'expect';
 
-import { execute } from '../src/index';
+import { execute, fork } from '../src/index';
 
 describe('Async executon', () => {
   describe('with asynchronously executing children', () => {
@@ -12,15 +12,15 @@ describe('Async executon', () => {
 
     beforeEach(() => {
       execution = execute(function() {
-        this.fork(function*() {
+        fork(function*() {
           yield cxt => one = cxt;
         });
 
-        this.fork(function*() {
+        fork(function*() {
           yield cxt => two = cxt;
         });
 
-        this.fork(function*() {
+        fork(function*() {
           yield cxt => three = cxt;
         });
       });
@@ -131,8 +131,8 @@ describe('Async executon', () => {
       error = undefined;
       boom = new Error('boom!');
       execution = execute(function*() {
-        this.fork(function*() { yield cxt => one = cxt; });
-        this.fork(function*() { yield cxt => two = cxt; });
+        fork(function*() { yield cxt => one = cxt; });
+        fork(function*() { yield cxt => two = cxt; });
         yield function*() {
           yield cxt => sync = cxt;
         };
@@ -256,7 +256,7 @@ describe('Async executon', () => {
     let parent, child;
     beforeEach(() => {
       parent = execute(function*() {
-        this.fork(function*() { yield cxt => child = cxt; });
+        fork(function*() { yield cxt => child = cxt; });
         yield x => x;
       });
     });
@@ -276,13 +276,12 @@ describe('Async executon', () => {
     });
   });
 
-
   describe('the fork function', () => {
     let a,b;
     let forkReturn, forkContext;
     beforeEach(() => {
       execute(function*() {
-        forkReturn = this.fork(function*(x, y) {
+        forkReturn = fork(function*(x, y) {
           forkContext = this;
           a = x;
           b = y;
@@ -300,5 +299,4 @@ describe('Async executon', () => {
       expect(forkReturn).toEqual(forkContext);
     });
   });
-
 });

--- a/tests/typescript/sequence.good.ts
+++ b/tests/typescript/sequence.good.ts
@@ -1,4 +1,4 @@
-import { Sequence } from 'effection';
+import { Sequence, fork } from 'effection';
 
 function* sequence(): Sequence {
   //bare generator function is ok
@@ -9,4 +9,8 @@ function* sequence(): Sequence {
 
   // other Operation also ok.
   yield sequence
+}
+
+function* asynchronous(): Sequence {
+  fork(sequence);
 }


### PR DESCRIPTION
Asynchronous operations are executed with the `fork()` method on `Execution` which is used to mark which exact process that you're forking off of. This is necessary because where you fork from determines who your parent will be and what happens when that parent is halted, or when you finish or error out who you need to report to.

The way we were accessing the current execution was via the `this` parameter inside of our operation functions. It was doen this way because it was easy. If you have a direct reference to the current execution, then it is very easy to fork off operations from it. Another rationale was that the `fork()` method _is_ effectful and so better to mark it as special by associating it with the `this` parameter. That way, it can be clearly seen as an imperative API.

It hasn't really panned out that way. In this day and age, it's is a very odd paradigm to be following as use of `this` is shunned. It also is a point of strangeness with the rest of the API since it is otherwise very functional in nature.

Since we can only have one execution running at a time (JS is single threaded after all), this change tracks a "current" execution which is used as the execution context any time that `fork` is called.

before:

```ts
export default function* main(env: Env): Sequence {
  this.fork(webAPI, [env.port]);
  this.fork(rtmAPI, [env.slackOAuthToken]);
}
```

after:

```ts
import { fork } from 'effection';

export default function* main(env: Env): Sequence {
  fork(webAPI, [env.port]);
  fork(rtmAPI, [env.slackOAuthToken]);
}
```