### PR TITLE
Unify execute() and fork()

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,14 +65,14 @@ siblings are immediately halted.
 ## Execution
 
 The process primitive is the `Execution`. To create (and start) an
-`Execution`, use the `execute` function and pass it a generator. This
+`Execution`, use the `fork` function and pass it a generator. This
 simplest example waits for 1 second, then prints out "hello world" to
 the console.
 
 ``` javascript
-import { execute, timeout } from 'effection';
+import { fork, timeout } from 'effection';
 
-let process = execute(function*() {
+let process = fork(function*() {
   yield timeout(1000);
   return 'hello world';
 });
@@ -87,7 +87,7 @@ Child processes can be composed freely. So instead of yielding for
 1000 ms, we could instead, yield 10 times for 100ms.
 
 ``` javascript
-execute(function*() {
+fork(function*() {
   yield function*() {
     for (let i = 0; i < 10; i++) {
       yield timeout(100);
@@ -100,7 +100,7 @@ execute(function*() {
 And in fact, processes can be easily and arbitrarly deeply nested:
 
 ``` javascript
-let process = execute(function*() {
+let process = fork(function*() {
   return yield function*() {
     return yield function*() {
       return yield function*() {
@@ -119,13 +119,13 @@ use the `call` function:
 
 ``` javascript
 
-import { execute, timeout, call } from 'effection';
+import { fork, timeout, call } from 'effection';
 
 function* waitForSeconds(durationSeconds) {
   yield timeout(durationSeconds * 1000);
 }
 
-execute(function*() {
+fork(function*() {
   yield call(waitforseconds, 10);
 });
 ```
@@ -144,7 +144,7 @@ function waitForSeconds(durationSeconds) {
 
 ### Asynchronous Execution
 
-Sometimes you want to execute some processes in parallel and not
+Sometimes you want to fork some processes in parallel and not
 necessarily block further execution on them. You still want the
 guarantees associated with structured concurrency however. For
 example, you might want to create a couple of different servers as
@@ -152,9 +152,9 @@ part of your main process. To do this, you would use the `fork` method
 on the execution:
 
 ``` javascript
-import { execute, fork } from 'effection';
+import { fork, fork } from 'effection';
 
-execute(function*() {
+fork(function*() {
   fork(createFileServer);
   fork(createHttpServer);
 });

--- a/examples/async.js
+++ b/examples/async.js
@@ -1,12 +1,12 @@
 /* eslint no-console: 0 */
 /* eslint require-yield: 0 */
-import { execute, fork, timeout } from '../src/index';
+import { fork, timeout } from '../src/index';
 
 
 /**
  * Fires up some random servers
  */
-execute(interruptable(function*() {
+fork(interruptable(function*() {
   fork(randoLogger('Bob'));
   fork(randoLogger('Alice'));
 

--- a/examples/countdown.js
+++ b/examples/countdown.js
@@ -1,5 +1,5 @@
 /* eslint no-console: 0 */
-import { execute, timeout } from '../src/index';
+import { fork, timeout } from '../src/index';
 
 
 /**
@@ -24,7 +24,7 @@ import { execute, timeout } from '../src/index';
  * handler is uninstalled. Once again, the node process is left with
  * nothing left to do and no event handlers, so it exits.
  */
-execute(interruptable(function*() {
+fork(interruptable(function*() {
   for (let i = 5; i > 0; i--) {
     console.log(`${i}...`);
     yield timeout(1000);

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,7 +10,6 @@ declare module "effection" {
     throw(error: Error): void;
   }
 
-  export function execute<T>(operation: Operation): Execution<T>;
   export function fork<T>(operation: Operation): Execution<T>;
 
   export function timeout(durationMillis: number): Operation;

--- a/src/execute.js
+++ b/src/execute.js
@@ -1,7 +1,0 @@
-import Execution from './execution';
-
-export function execute(operation) {
-  let execution = Execution.of(operation);
-  execution.start();
-  return execution;
-}

--- a/src/execution.js
+++ b/src/execution.js
@@ -7,6 +7,12 @@ export default class Execution {
     return new Execution(operation, x => x);
   }
 
+  static start(operation) {
+    let execution = Execution.of(operation);
+    execution.start();
+    return execution;
+  }
+
   get isUnstarted() { return this.status instanceof Unstarted; }
   get isRunning() { return this.status instanceof Running; }
   get isBlocking() { return this.isRunning || this.isWaiting; }
@@ -238,6 +244,9 @@ function controllerFor(value) {
 }
 
 export function fork(operation) {
+  if (currentExecution == null) {
+    return Execution.start(operation);
+  }
   let parent = currentExecution;
 
   let child = new Execution(operation).then(() => {

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,3 @@
-export { execute } from './execute';
 export { timeout } from './timeout';
 export { fork } from './execution';
 export { promiseOf } from './promise-of';

--- a/tests/async.test.js
+++ b/tests/async.test.js
@@ -4,14 +4,14 @@
 
 import expect from 'expect';
 
-import { execute, fork } from '../src/index';
+import { fork } from '../src/index';
 
 describe('Async executon', () => {
   describe('with asynchronously executing children', () => {
     let execution, one, two, three;
 
     beforeEach(() => {
-      execution = execute(function() {
+      execution = fork(function() {
         fork(function*() {
           yield cxt => one = cxt;
         });
@@ -130,7 +130,7 @@ describe('Async executon', () => {
     beforeEach(() => {
       error = undefined;
       boom = new Error('boom!');
-      execution = execute(function*() {
+      execution = fork(function*() {
         fork(function*() { yield cxt => one = cxt; });
         fork(function*() { yield cxt => two = cxt; });
         yield function*() {
@@ -255,7 +255,7 @@ describe('Async executon', () => {
   describe('A parent that block, but also has an async child', () => {
     let parent, child;
     beforeEach(() => {
-      parent = execute(function*() {
+      parent = fork(function*() {
         fork(function*() { yield cxt => child = cxt; });
         yield x => x;
       });
@@ -279,7 +279,7 @@ describe('Async executon', () => {
   describe('the fork function', () => {
     let forkReturn, forkContext;
     beforeEach(() => {
-      execute(function*() {
+      fork(function*() {
         forkReturn = fork(function*() {
           forkContext = this;
         });

--- a/tests/controller.test.js
+++ b/tests/controller.test.js
@@ -2,7 +2,7 @@
 
 import expect from 'expect';
 
-import { execute } from '../src/index';
+import { fork } from '../src/index';
 import mock from 'jest-mock';
 
 describe('Controlling execution', () => {
@@ -22,7 +22,7 @@ describe('Controlling execution', () => {
     beforeEach(() => {
       relinquish = mock.fn();
 
-      execution = execute(function*() {
+      execution = fork(function*() {
         yield control;
       }).catch(e => error = e);
 
@@ -69,7 +69,7 @@ describe('Controlling execution', () => {
   describe('from an intermediate step in an execution', () => {
     beforeEach(() => {
       relinquish = mock.fn();
-      execute(function* () {
+      fork(function* () {
         yield control;
         yield ctl => ctl.resume();
       });
@@ -85,7 +85,7 @@ describe('Controlling execution', () => {
   describe('a release function that throws an error', () => {
     beforeEach(() => {
       relinquish = () => { throw new Error('this is a bug in the release control!'); };
-      execute(function* () {
+      fork(function* () {
         yield control;
       });
     });

--- a/tests/execute.test.js
+++ b/tests/execute.test.js
@@ -5,7 +5,7 @@
 import expect from 'expect';
 import mock from 'jest-mock';
 
-import { execute } from '../src/index';
+import { fork } from '../src/index';
 
 describe('Exec', () => {
   describe('deeply nested task', () => {
@@ -15,7 +15,7 @@ describe('Exec', () => {
       onSuccess = mock.fn(x => x);
       onError = mock.fn(x => x);
       onFinally = mock.fn(x => x);
-      execution = execute(function*() {
+      execution = fork(function*() {
         try {
           return yield function*() {
             return yield function*() {
@@ -110,7 +110,7 @@ describe('Exec', () => {
   describe('deeply nested task that throws an error', () => {
     let execution, error;
     beforeEach(() => {
-      execution = execute(function*() {
+      execution = fork(function*() {
         try {
           return yield function*() {
             return yield function*() {
@@ -139,7 +139,7 @@ describe('Exec', () => {
     let id = x => x;
 
     beforeEach(() => {
-      execution = execute(function*() {
+      execution = fork(function*() {
         return yield function*() {
           return yield function*() {
             return yield function*() {
@@ -189,7 +189,7 @@ describe('Exec', () => {
     let execution, error;
 
     beforeEach(() => {
-      execution = execute(function*() {
+      execution = fork(function*() {
         return yield;
       }).catch(e => error = e);
     });
@@ -230,7 +230,7 @@ describe('Exec', () => {
     describe('nested inside generator functions', () => {
       beforeEach(() => {
 
-        execution = execute(function*() {
+        execution = fork(function*() {
           let one = yield function*() { return 1; };
           let two = yield function*() { return 2; };
           return yield add(one, two);
@@ -245,7 +245,7 @@ describe('Exec', () => {
 
     describe('directly', () => {
       beforeEach(() => {
-        execution = execute(add(1, 2));
+        execution = fork(add(1, 2));
       })
       it('computes the result just fine', () => {
         expect(execution.isCompleted).toEqual(true);

--- a/tests/promise-of.test.js
+++ b/tests/promise-of.test.js
@@ -1,6 +1,6 @@
 import expect from 'expect';
 
-import { execute } from '../src/index';
+import { fork } from '../src/index';
 
 describe('yielding on a promise', () => {
   let execution, deferred, error;
@@ -8,7 +8,7 @@ describe('yielding on a promise', () => {
   beforeEach(() => {
     error = undefined;
     deferred = new Deferred();
-    execution = execute(function*() {
+    execution = fork(function*() {
       try {
         return yield deferred.promise;
       } catch (e) {

--- a/tests/typescript/execute.bad.ts
+++ b/tests/typescript/execute.bad.ts
@@ -1,3 +1,3 @@
-import { Execution, Sequence, execute } from 'effection';
+import { fork } from 'effection';
 
-execute(5);
+fork(5);

--- a/tests/typescript/execute.good.ts
+++ b/tests/typescript/execute.good.ts
@@ -1,17 +1,17 @@
-import { Execution, Sequence, execute } from 'effection';
+import { Execution, Sequence, fork } from 'effection';
 
 function* operation(): Sequence {}
 
 let execution: Execution;
 
-execution = execute(operation);
+execution = fork(operation);
 
-execution = execute(operation());
+execution = fork(operation());
 
-execution = execute(Promise.resolve("hello world"));
+execution = fork(Promise.resolve("hello world"));
 
-execution = execute(function*() {});
+execution = fork(function*() {});
 
-execution = execute(undefined);
+execution = fork(undefined);
 
-execution = execute((execution: Execution<void>) => execution.resume());
+execution = fork((execution: Execution<void>) => execution.resume());

--- a/tests/typescript/imports.ts
+++ b/tests/typescript/imports.ts
@@ -2,7 +2,6 @@ import {
   Operation,
   Sequence,
   Execution,
-  execute,
   fork,
   timeout
 } from 'effection';


### PR DESCRIPTION
With `fork()` now being a static function, and operations all being atoms that don't have arguments, the signature for `fork()` and `execute()` became exactly the same:

```ts
fork(operation) => Execution
execute(operation) => Execution
```

It wasn't hard to see that `execute` was nothing more than a "root" fork. Or a just fork that had no existing context, so it made it much more conceptually simple to eliminate one in favor of the other.

This removes the `execute` function altogether, and adds a base case to `fork()` where if the current execution is not defined, it creates a brand new execution to serve as the root context.