### PR TITLE
prepare release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.3.0] - 2019-10-18
+
+- unify the fork() and execute() methods. There is now a single API
+  for initiating asynchronous execution, fork() which makes the mental
+  model much simpler and the learning curve smaller.
+  https://github.com/thefrontside/effection.js/pull/14
+
+- make the fork() function static. Prior to this, `fork()` was a
+  method on the `Execution` class which made the API awkward and
+  non-functional.
+  https://github.com/thefrontside/effection.js/pull/12
+
+- make generators (not just generator functions) valid
+  operations. Before this change, you needed to use a utility function
+  `call()` in order to pass arguments to generator based
+  operations. This lets you invoke generator functions directly and
+  pass the resulting generator to `yield` and `fork` directly thus
+  simplifying code greatly.
+  https://github.com/thefrontside/effection.js/pull/13
+
 ## [0.2.0] - 2019-10-17
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "effection",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Effortlessly composable structured concurrency primitive for JavaScript",
   "repository": "http://github.com/cowboyd/effection.js",
   "author": "Charles Lowell <cowboyd@frontside.io>",


### PR DESCRIPTION
## [0.3.0] - 2019-10-18

- unify the fork() and execute() methods. There is now a single API for initiating asynchronous execution, fork() which makes the mental model much simpler and the learning curve smaller. https://github.com/thefrontside/effection.js/pull/14

- make the fork() function static. Prior to this, `fork()` was a method on the `Execution` class which made the API awkward and non-functional. https://github.com/thefrontside/effection.js/pull/12

- make generators (not just generator functions) valid operations. Before this change, you needed to use a utility function `call()` in order to pass arguments to generator based operations. This lets you invoke generator functions directly and pass the resulting generator to `yield` and `fork` directly thus simplifying code greatly. https://github.com/thefrontside/effection.js/pull/13