### PR TITLE
Update preview workflow for effection.js

### DIFF
--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -12,15 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Write NPM Snapshot Version
-      uses: thefrontside/actions/write-npm-snapshot-version@master
-    - name: NPM Publish Commit
-      uses: thefrontside/actions/npm-publish-branch-preview@master
-      env:
-        NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+    - name: NPM Publish Preview
+      uses: thefrontside/actions/publish-pr-preview@master
       with:
         NPM_PUBLISH: npm run pack:publish
-    - name: Post Instructions Comment
-      uses: thefrontside/actions/post-npm-usage-instructions-comment@master
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_POST_COMMENT_TOKEN }}
+        NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
This PR is to update the `publish-preview` workflow to use the refactored action instead of the three that it's currently using. This will make it much easier for us to make changes to the workflow and action in the future without having to update every project that uses TNP.

See [`thefrontside/actions` PR #29](https://github.com/thefrontside/actions/pull/29) to better understand why we're making this update.

## TODO
- [x] Merge [`thefrontside/actions` PR #29](https://github.com/thefrontside/actions/pull/29)