### PR TITLE
🐛Don't mark a running fork as completed when a child is halted

### DIFF
--- a/src/fork.js
+++ b/src/fork.js
@@ -140,7 +140,7 @@ Thanks!
       if (child.sync) {
         this.throw(new Error(`Interupted: ${child.result}`));
       } else {
-        if (!this.hasBlockingChildren) {
+        if (this.isWaiting && !this.hasBlockingChildren) {
           this.finalize('completed');
         }
       }

--- a/tests/async.test.js
+++ b/tests/async.test.js
@@ -274,6 +274,15 @@ describe('Async executon', () => {
         expect(parent.isRunning).toEqual(true);
       });
     });
+
+    describe('when the async child is halted', () => {
+      beforeEach(() => {
+        child.halt();
+      });
+      it('keeps the parent running because it is still yielding on its own', () => {
+        expect(parent.isRunning).toEqual(true);
+      });
+    });
   });
 
   describe('the fork function', () => {


### PR DESCRIPTION
When you have the case of a parent `A` that is running, and also that parent has a forked child `B` that becomes halted. `A`, because it is still yielding should continue running. If on the other hand, `A` is waiting, then it should be completed because that was the last blocking child.

```
A
 - B
```

Howewer, we only checked that the parent did not have blocking children, and not that it was also just waiting (and not running).

This adds the check to the `join()` method to ensure that running parents continue running even when a child is halted.