### PR TITLE
Always cleanup children

### DIFF
--- a/src/fork.js
+++ b/src/fork.js
@@ -140,7 +140,7 @@ Thanks!
       if (child.sync) {
         this.throw(new Error(`Interupted: ${child.result}`));
       } else {
-        if (!this.hasBlockingChildren) {
+        if (this.isWaiting && !this.hasBlockingChildren) {
           this.finalize('completed');
         }
       }

--- a/tests/async.test.js
+++ b/tests/async.test.js
@@ -282,6 +282,9 @@ describe('Async executon', () => {
       it('keeps the parent running because it is still yielding on its own', () => {
         expect(parent.isRunning).toEqual(true);
       });
+      it('removes the child from the list of children', () => {
+        expect(parent.children.has(child)).toEqual(false);
+      });
     });
   });
 

--- a/tests/async.test.js
+++ b/tests/async.test.js
@@ -274,6 +274,15 @@ describe('Async executon', () => {
         expect(parent.isRunning).toEqual(true);
       });
     });
+
+    describe('when the async child is halted', () => {
+      beforeEach(() => {
+        child.halt();
+      });
+      it('keeps the parent running because it is still yielding on its own', () => {
+        expect(parent.isRunning).toEqual(true);
+      });
+    });
   });
 
   describe('the fork function', () => {


### PR DESCRIPTION
When debugging an effection application, we noticed that in the case where you had halted children, they were not being removed from parents that were still running. That meant that you have a fork tree looking like:

```
Fork {
   state: waiting
   operation: main
   children:
     Fork {
       state: running
       operation:
       children:
     }
     Fork {
       state: running
       operation:
       children:
           Fork {
             state: halted
             operation: setupConnection
             children:
           }
     }
}
```

Which means that if the the parent is long running, then you can accrue lots of halted children which is a memory leak.

This makes sure that _every_ time that a child joins its parent, it is removed from the list of children. This is safe because join _only_ happens on finalization of a child.