### PR TITLE
Add `halt()` to execution signature

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,6 +8,7 @@ declare module "effection" {
   export interface Execution<T = any> {
     resume(result: T): void;
     throw(error: Error): void;
+    halt(reason?: any): void;
   }
 
   export function fork<T>(operation: Operation): Execution<T>;

--- a/tests/typescript/execute.good.ts
+++ b/tests/typescript/execute.good.ts
@@ -14,4 +14,9 @@ execution = fork(function*() {});
 
 execution = fork(undefined);
 
-execution = fork((execution: Execution<void>) => execution.resume());
+execution = fork((execution: Execution<number>) => {
+  execution.resume(10);
+  execution.halt("optional reason");
+  execution.halt();
+  execution.throw(new Error('boom!'));
+});


### PR DESCRIPTION
For each execution context, there are three possible outcomes: completed, errored, or halted. The execution interface however only accounts for two of them in the official type signatures.

Because cancellation through halt is a critical api, and is already in use in other projects, this adds it to the official type declarations.