### PR TITLE
Add `id` field to each execution

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "plugins": ["@babel/plugin-proposal-class-properties"]
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,6 +6,7 @@ declare module "effection" {
   export interface Sequence extends Generator<Operation, any, any> {}
 
   export interface Execution<T = any> {
+    id: number;
     resume(result: T): void;
     throw(error: Error): void;
     halt(reason?: any): void;

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "devDependencies": {
     "@babel/core": "7.4.4",
+    "@babel/plugin-proposal-class-properties": "^7.7.0",
     "@babel/preset-env": "7.4.4",
     "@babel/register": "7.4.4",
     "@pika/pack": "0.3.7",

--- a/src/fork.js
+++ b/src/fork.js
@@ -4,6 +4,7 @@ import { isGenerator, isGeneratorFunction, toGeneratorFunction } from './generat
 import Continuation from './continuation';
 
 class Fork {
+  static ids = 0;
   get isUnstarted() { return this.state === 'unstarted'; }
   get isRunning() { return this.state === 'running'; }
   get isWaiting() { return this.state === 'waiting'; }
@@ -23,6 +24,7 @@ class Fork {
   }
 
   constructor(operation, parent, sync) {
+    this.id = Fork.ids++;
     this.operation = toGeneratorFunction(operation);
     this.parent = parent;
     this.sync = sync;

--- a/tests/execute.test.js
+++ b/tests/execute.test.js
@@ -28,8 +28,16 @@ describe('Exec', () => {
       });
     });
 
+    it('has an id', () => {
+      expect(typeof execution.id).toEqual('number');
+    });
+
     it('calls all the way through to the inner child', () => {
       expect(inner).toBeDefined();
+    });
+
+    it('allocates a bigger number to the child id', () => {
+      expect(inner.id > execution.id).toEqual(true);
     });
 
     it('does not invoke any callback', () => {

--- a/tests/typescript/execute.good.ts
+++ b/tests/typescript/execute.good.ts
@@ -15,6 +15,7 @@ execution = fork(function*() {});
 execution = fork(undefined);
 
 execution = fork((execution: Execution<number>) => {
+  execution.id;
   execution.resume(10);
   execution.halt("optional reason");
   execution.halt();


### PR DESCRIPTION
It's nice when debugging to see how forks relate to each other both inside and outside of code. To do this you need a consistent way to identify a fork.

This adds an `id` field which is allocated from a static id sequence inside the Fork constructor. I've opted to install the class properties syntax since it is so pervasive and cleaner than using a module variable.

I also like the idea of being able to read it as a property from the `Fork` constructor rather than have it completely hidden inside a module variable.

resolves #27