### PR TITLE
Make sure errors thrown in controller destructors are rethrown

### DIFF
--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -7,13 +7,13 @@ on:
       - release-*
 
 jobs:
-  preview: 
+  preview:
     name: Publish Preview Package
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
     - name: NPM Publish Preview
-      uses: thefrontside/actions/publish-pr-preview@master
+      uses: thefrontside/actions/publish-pr-preview@2be7576
       with:
         NPM_PUBLISH: npm run pack:publish
       env:

--- a/tests/execute.test.js
+++ b/tests/execute.test.js
@@ -254,7 +254,7 @@ describe('Exec', () => {
     describe('directly', () => {
       beforeEach(() => {
         execution = fork(add(1, 2));
-      })
+      });
       it('computes the result just fine', () => {
         expect(execution.isCompleted).toEqual(true);
         expect(execution.result).toEqual(3);


### PR DESCRIPTION
Currently they are sometimes caught mistakenly, by making the `try` block smaller we ensure that it does not cover calls to exitPrevious.