### PR TITLE
Prevent chaining from accidentally converting Fork into Promise

### DIFF
--- a/src/promise-of.js
+++ b/src/promise-of.js
@@ -9,7 +9,7 @@ export function promiseOf(promise) {
     let fail = err => execution.throw(err);
     let noop = x => x;
 
-    promise.then(value => succeed(value), error => fail(error));
+    promise.then(value => { succeed(value) }, error => { fail(error) });
 
     // this execution has passed out of scope, so we don't care
     // what happened to the promise, so make the callbacks noops.

--- a/src/promise-of.js
+++ b/src/promise-of.js
@@ -9,6 +9,8 @@ export function promiseOf(promise) {
     let fail = err => execution.throw(err);
     let noop = x => x;
 
+    // return values of succeed and fail are deliberately ignored.
+    // see https://github.com/thefrontside/effection.js/pull/44
     promise.then(value => { succeed(value) }, error => { fail(error) });
 
     // this execution has passed out of scope, so we don't care


### PR DESCRIPTION
This is a bug which is hard to prove via a test case, hence the absence of an accompanying test. The problem here is that `succeed` calls `resume`, which returns the execution itself (there's a `return this` on the last line of `resume`).

If the result of a promise's `then` method is itself a promise, then the promise returned by `then` will resolve once *that* promise has resolved. This enables chaining and is useful.

However, in our case, it's actually bad, since `Fork` is a promise, the promise returned by `then` will wait for this promise to resolve, by calling `then` on our fork.

We then proceed to ignore the result of this promise. If the fork completes, this is no problem, but if it errors or halts, then this causes node to print an ugly warning telling us that there was an unhandled rejection.

By simply wrapping in curly braces, we don't return anything from the handlers, and therefore, `Fork` will never get converted to a promise, and we don't get the warning.

And yes, this was very annoying to track down 😅