### PR TITLE
Remove unused export

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,2 @@
 export { timeout } from './timeout';
 export { fork } from './fork';
-export { promiseOf } from './promise-of';


### PR DESCRIPTION
In a different time, you had to manually wrap every promise before
yielding to it with a call to `promiseOf`

```js
function* doStuff() {
  yield promiseOf(new Promise((resolve, reject) => {/*....*/)));
}
```

But now that you can yield to promises directly, there's no need for
you to ever call this function.