### PR TITLE
Make then/catch/finally callable from typescript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,11 +5,13 @@ declare module "effection" {
 
   export interface Sequence extends Generator<Operation, any, any> {}
 
-  export interface Execution<T = any> {
+  export interface Execution<T = any> extends PromiseLike<any> {
     id: number;
     resume(result: T): void;
     throw(error: Error): void;
     halt(reason?: any): void;
+    catch<R>(fn: (Error) => R): Promise<R>;
+    finally(fn: () => void): Promise<any>;
   }
 
   export function fork<T>(operation: Operation): Execution<T>;

--- a/tests/typescript/promise.ts
+++ b/tests/typescript/promise.ts
@@ -9,4 +9,13 @@ async function someAsyncFunction() {
     fork(function*() { yield }),
     fork(function*() { yield }),
   ]);
+
+  let someFork = fork(function*() {
+    yield
+    return 123;
+  });
+
+  someFork.then((value: number) => {}, (error) => {});
+  someFork.catch((error: Error) => "string").then((some: string) => {});
+  someFork.finally(() => "string").then((some: number) => {});
 }


### PR DESCRIPTION
While it is currently possible to use executions with aysnc/await and `Promise.all`, actually `then`/`catch`/`finally` is not allowed from TypeScript. This just adds these methods to the public interface.