### PR TITLE
♻Always resume fork evaluation on next tick

### DIFF
--- a/src/fork.js
+++ b/src/fork.js
@@ -11,7 +11,7 @@ class Fork {
   get isErrored() { return this.state === 'errored'; }
   get isHalted() { return this.state === 'halted'; }
 
-  get isBlocking() { return this.isRunning || this.isWaiting; }
+  get isBlocking() { return this.isRunning || this.isWaiting || this.isUnstarted; }
 
   get hasBlockingChildren() {
     for (let child of this.children) {
@@ -103,7 +103,9 @@ Thanks!`);
   fork(operation, sync = false) {
     let child = new Fork(operation, this, sync);
     this.children.add(child);
-    child.resume();
+    setTimeout(() => {
+      child.resume();
+    }, 0);
     return child;
   }
 

--- a/tests/async.test.js
+++ b/tests/async.test.js
@@ -130,7 +130,7 @@ describe('Async executon', () => {
   describe('with a mixture of synchronous and asynchronous executions', () => {
     let execution, one, two, sync, boom;
     beforeEach(async () => {
-      await new Promise((resolve, reject) => {
+      await new Promise((resolve) => {
         boom = new Error('boom!');
         execution = fork(function*() {
           fork(function*() { yield cxt => one = cxt; });
@@ -139,7 +139,7 @@ describe('Async executon', () => {
             yield cxt => (sync = cxt) && resolve();
           };
         });
-      })
+      });
       expect(one).toBeDefined();
       expect(two).toBeDefined();
       expect(sync).toBeDefined();

--- a/tests/execute.test.js
+++ b/tests/execute.test.js
@@ -11,7 +11,7 @@ describe('Exec', () => {
   describe('deeply nested task', () => {
     let inner, execution, error;
     let onSuccess, onError, onFinally;
-    beforeEach(() => {
+    beforeEach((done) => {
       onSuccess = mock.fn(x => x);
       onError = mock.fn(x => x);
       onFinally = mock.fn(x => x);
@@ -19,7 +19,10 @@ describe('Exec', () => {
         try {
           return yield function*() {
             return yield function*() {
-              return yield ctl => inner = ctl;
+              return yield ctl => {
+                inner = ctl;
+                done();
+              };
             };
           };
         } catch (e) {
@@ -118,7 +121,7 @@ describe('Exec', () => {
   describe('deeply nested task that throws an error', () => {
     let execution, error;
     beforeEach(() => {
-      execution = fork(function*() {
+      return execution = fork(function*() {
         try {
           return yield function*() {
             return yield function*() {
@@ -185,8 +188,7 @@ describe('Exec', () => {
 
     describe('nested inside generator functions', () => {
       beforeEach(() => {
-
-        execution = fork(function*() {
+        return execution = fork(function*() {
           let one = yield function*() { return 1; };
           let two = yield function*() { return 2; };
           return yield add(one, two);

--- a/tests/fork-as-promise.test.js
+++ b/tests/fork-as-promise.test.js
@@ -3,17 +3,15 @@ import mock from 'jest-mock';
 
 import { fork } from '../src/index';
 
-async function suspend() {}
-
 describe('forks as promises', () => {
   let root, child;
 
-  beforeEach(async () => {
+  beforeEach((done) => {
     root = fork(function*() {
       child = fork(function* () {
+        done();
         return yield;
       });
-
       return yield;
     });
   });
@@ -32,95 +30,126 @@ describe('forks as promises', () => {
     });
 
     it('starts off in pending state', async () => {
-      await suspend();
-
       expect(onResolveRoot).not.toHaveBeenCalled();
       expect(onResolveChild).not.toHaveBeenCalled();
       expect(onRejectRoot).not.toHaveBeenCalled();
       expect(onRejectChild).not.toHaveBeenCalled();
     });
 
-    it('resolves inner when inner operation finishes', async () => {
-      child.resume(123);
-      await suspend();
 
-      expect(onResolveRoot).not.toHaveBeenCalled();
-      expect(onResolveChild).toHaveBeenCalledWith(123);
-      expect(onRejectRoot).not.toHaveBeenCalled();
-      expect(onRejectChild).not.toHaveBeenCalled();
+    describe('when inner operation finishes', () => {
+      beforeEach(async () => {
+        child.resume(123);
+      });
+
+      it('resolves inner', () => {
+        expect(onResolveRoot).not.toHaveBeenCalled();
+        expect(onResolveChild).toHaveBeenCalledWith(123);
+        expect(onRejectRoot).not.toHaveBeenCalled();
+        expect(onRejectChild).not.toHaveBeenCalled();
+      });
     });
 
-    it('resolves when operation and all children finish', async () => {
-      child.resume(123);
-      root.resume(567);
-      await suspend();
 
-      expect(onResolveRoot).toHaveBeenCalledWith(567);
-      expect(onResolveChild).toHaveBeenCalledWith(123);
-      expect(onRejectRoot).not.toHaveBeenCalled();
-      expect(onRejectChild).not.toHaveBeenCalled();
+
+    describe('when operation and all children finish', () => {
+      beforeEach(async () => {
+        child.resume(123);
+        root.resume(567);
+      });
+
+      it('resolves when operation and all children finish', () => {
+        expect(onResolveRoot).toHaveBeenCalledWith(567);
+        expect(onResolveChild).toHaveBeenCalledWith(123);
+        expect(onRejectRoot).not.toHaveBeenCalled();
+        expect(onRejectChild).not.toHaveBeenCalled();
+      });
     });
 
-    it('rejects when child errors', async () => {
-      child.throw(new Error('boom'));
-      await suspend();
 
-      expect(onResolveRoot).not.toHaveBeenCalled();
-      expect(onResolveChild).not.toHaveBeenCalled();
-      expect(onRejectRoot).toHaveBeenCalledWith(expect.objectContaining({ message: 'boom' }));
-      expect(onRejectChild).toHaveBeenCalledWith(expect.objectContaining({ message: 'boom' }));
+    describe('when child errors', () => {
+      beforeEach(async () => {
+        child.throw(new Error('boom'));
+      });
+
+      it('rejects',  () => {
+        expect(onResolveRoot).not.toHaveBeenCalled();
+        expect(onResolveChild).not.toHaveBeenCalled();
+        expect(onRejectRoot).toHaveBeenCalledWith(expect.objectContaining({ message: 'boom' }));
+        expect(onRejectChild).toHaveBeenCalledWith(expect.objectContaining({ message: 'boom' }));
+      });
     });
 
-    it('rejects when parent errors (child is halted)', async () => {
-      root.throw(new Error('boom'));
-      await suspend();
+    describe('when parent errors', () => {
+      beforeEach(async () => {
+        root.throw(new Error('boom'));
+      });
 
-      expect(onResolveRoot).not.toHaveBeenCalled();
-      expect(onResolveChild).not.toHaveBeenCalled();
-      expect(onRejectRoot).toHaveBeenCalledWith(
-        expect.objectContaining({ message: 'boom' })
-      );
-      expect(onRejectChild).toHaveBeenCalledWith(
-        expect.objectContaining({
-          message: 'halt',
-          cause: expect.objectContaining({ message: 'boom' })
-        })
-      );
+      it('rejects the parent and child (halted)', () => {
+        expect(onResolveRoot).not.toHaveBeenCalled();
+        expect(onResolveChild).not.toHaveBeenCalled();
+        expect(onRejectRoot).toHaveBeenCalledWith(
+          expect.objectContaining({ message: 'boom' })
+        );
+        expect(onRejectChild).toHaveBeenCalledWith(
+          expect.objectContaining({
+            message: 'halt',
+            cause: expect.objectContaining({ message: 'boom' })
+          })
+        );
+      });
     });
 
-    it('rejects with halt when parent halts', async () => {
-      root.halt();
-      await suspend();
+    describe('when parent halts with no result', () => {
+      beforeEach(async () => {
+        root.halt();
+      });
 
-      expect(onResolveRoot).not.toHaveBeenCalled();
-      expect(onResolveChild).not.toHaveBeenCalled();
-      expect(onRejectRoot).toHaveBeenCalledWith(expect.objectContaining({ message: 'halt' }));
-      expect(onRejectChild).toHaveBeenCalledWith(expect.objectContaining({ message: 'halt' }));
+      it('rejects with halt when parent halts', () => {
+        expect(onResolveRoot).not.toHaveBeenCalled();
+        expect(onResolveChild).not.toHaveBeenCalled();
+        expect(onRejectRoot).toHaveBeenCalledWith(expect.objectContaining({ message: 'halt' }));
+        expect(onRejectChild).toHaveBeenCalledWith(expect.objectContaining({ message: 'halt' }));
+      });
     });
 
-    it('rejects with halt with result when parent halts', async () => {
-      root.halt(999);
-      await suspend();
+    describe('when parent halts with reason', () => {
+      beforeEach(async () => {
+        root.halt(999);
+      });
 
-      expect(onResolveRoot).not.toHaveBeenCalled();
-      expect(onResolveChild).not.toHaveBeenCalled();
-      expect(onRejectRoot).toHaveBeenCalledWith(expect.objectContaining({ message: 'halt', cause: 999 }));
-      expect(onRejectChild).toHaveBeenCalledWith(expect.objectContaining({ message: 'halt', cause: 999 }));
+      it('rejects with halt with result when parent halts', () => {
+        expect(onResolveRoot).not.toHaveBeenCalled();
+        expect(onResolveChild).not.toHaveBeenCalled();
+        expect(onRejectRoot).toHaveBeenCalledWith(expect.objectContaining({ message: 'halt', cause: 999 }));
+        expect(onRejectChild).toHaveBeenCalledWith(expect.objectContaining({ message: 'halt', cause: 999 }));
+      });
     });
   });
 
   describe('with promise attached after finalization', function() {
-    it('starts is resolved immediately', async () => {
-      child.resume(567);
-      root.resume(123);
-      await expect(child).resolves.toBe(567);
-      await expect(root).resolves.toBe(123);
+    describe('when completed', () => {
+      beforeEach(async () => {
+        child.resume(567);
+        root.resume(123);
+      });
+
+      it('starts is resolved immediately', async () => {
+        await expect(child).resolves.toBe(567);
+        await expect(root).resolves.toBe(123);
+      });
     });
 
-    it('starts is rejected immediately if halted', async () => {
-      root.halt();
-      await expect(root).rejects.toThrow('halt');
+    describe('when halted', () => {
+      beforeEach(async () => {
+        root.halt();
+      });
+      it('starts is rejected immediately if halted', async () => {
+        await expect(root).rejects.toThrow('halt');
+      });
     });
+
+
 
     it('starts is rejected immediately if errored', async () => {
       root.throw(new Error('boom'));

--- a/tests/root.test.js
+++ b/tests/root.test.js
@@ -9,10 +9,11 @@ import { fork } from '../src/index';
 describe('Root', () => {
   let execution, child, grandchild;
 
-  beforeEach(() => {
+  beforeEach((done) => {
     execution = fork(function() {
       child = fork(function*() {
         grandchild = fork(function*() {
+          done();
           yield;
         });
       });


### PR DESCRIPTION
Currently, forks execute synchronously until their first yield point. Which means that if we have:

```js
fork(function* outer() {
  fork(function* inner() {
    throw new Error('boom!');
  });
})
```

It will attempt to throw an error into the outer generator function while that generator function is still running. This causes the original exception to be obscured.

For a full write up see here https://github.com/thefrontside/effection.js/issues/26

This change implements the first option in that ticket by making sure that calling `Fork#resume()` does not continue the computation at that point, but instead merely _schedules_ it to be continued. This was a pretty easy change to make. In fact, the biggest impact seems to be that forks do exist for some time in the `unstarted` state and so it's important that `unstarted` be considered a blocking state since otherwise, a parent with no yield points would just consider itself done if it had no blocking children.

Pros
====

* Very simple resolution to the issue, and simplicity has an elegance all its own.

Cons
====

* _Loses the stack trace when there is an exception_: In the event that you _do_ have an error the stack trace will be very short, basically just a direct line from `setTimeout`:
  ```js
    at child.resume();
    at applicationErrorLocation();
  ````
* _Testing is more complex:_ I'm not sure if this is indicative of a deeper issue, but it's definitely more fiddly and that makes me a tad nervous
* Loses the simplicity of a single, continuous computation: There is a  certain elegance to the idea the entire tree is once continuos  computation only broken appart by yield points. By introducing  another form of asynchrony (forks happening in next tick). There are   now two timing mechanisms that you have to hold in your head so that   you don't get caught out by subtle bugs. For example, take the code here:

  ```js
  function* networkStuff(host, port) {
    let socket = createConnection(port, host);

    let monitor = fork(function* errors() {
      let [error]: [Error] = yield on(socket, 'error');
      throw error;
    })

    yield on(socket, 'ready');

    socket.write(data);
  }
  ```
  There is a potential to "miss" an error event here because with this  change, the `error` event listener will not be installed until at   least the next tick of the run loop _after_ the socket connection has   been attempted. If an error is emitted between those two points, then  it will be dropped on the floor. This seems especially likely with something like EADDRINUSE.

It's possible to avoid this by creating the socket and then connecting to it in two separate steps:

```js
 function* networkStuff(host, port) {
    let socket = new Socket(); 

    let monitor = fork(function* errors() {
      let [error]: [Error] = yield on(socket, 'error');
      throw error;
    })

    //must happen after monitor install
    socket.connect(host, port);

    yield on(socket, 'ready');

    socket.write(data);
  }
```

But it does feel weird that if you were to move the socket connection up above the monitor creation, then you'd be back in the same boat.