### PR TITLE
Update action source from master to v1.1

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Tag and Publish
-      uses: thefrontside/actions/synchronize-with-npm@master
+      uses: thefrontside/actions/synchronize-with-npm@v1.1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/synchronize-npm-tags.yml
+++ b/.github/workflows/synchronize-npm-tags.yml
@@ -9,6 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - uses: thefrontside/actions/synchronize-npm-tags@master
+    - uses: thefrontside/actions/synchronize-npm-tags@v1.1
       env:
         NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
We're going to be introducing some breaking changes and so we created a "save point" by tagging and releasing the current state of our `thefrontside/actions` as `v1.1`. There might be other bugs but going from `master` to `v1.1` in this repository's workflows should not be any different as `master` and `v1.1` are identical at the moment.

Updated `release` and `synchronize-npm-tags` to `v1.1`. I left the preview workflow action as `v1` because the reason why `v1` was even released was for that workflow to begin with.