### PR TITLE
Add the ability to synchronous destructors

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -13,6 +13,7 @@ declare module "effection" {
     halt(reason?: any): void;
     catch<R>(fn: (error: Error) => R): Promise<R>;
     finally(fn: () => void): Promise<any>;
+    atExit(fn: () => void): void;
   }
 
   export function fork<T>(operation: Operation): Execution<T>;

--- a/src/fork.js
+++ b/src/fork.js
@@ -28,6 +28,7 @@ class Fork {
     this.parent = parent;
     this.sync = sync;
     this.children = new Set();
+    this.atExitHooks = [];
     this.state = 'unstarted';
     this.exitPrevious = noop;
   }
@@ -51,6 +52,10 @@ class Fork {
 
   finally(...args) {
     return this.promise.finally(...args);
+  }
+
+  atExit(fn) {
+    this.atExitHooks.push(fn);
   }
 
   halt(value) {
@@ -193,6 +198,7 @@ https://github.com/thefrontside/effection.js/issues/new
     if (this.parent) {
       this.parent.join(this);
     }
+    this.atExitHooks.forEach((fn) => fn(this));
     this.finalizePromise();
   }
 

--- a/tests/at-exit.test.js
+++ b/tests/at-exit.test.js
@@ -1,0 +1,39 @@
+/* global describe, beforeEach, it */
+/* eslint require-yield: 0 */
+/* eslint no-unreachable: 0 */
+
+import expect from 'expect';
+
+import { fork } from '../src/index';
+
+describe('atExit', () => {
+  let execution, thing;
+
+  beforeEach(() => {
+    execution = fork(function*() {
+      return yield;
+    });
+    execution.atExit(() => {
+      thing = "ran at exit";
+    });
+  });
+
+  it('does not run before exit of exection', () => {
+    expect(thing).toEqual(undefined);
+  });
+
+  it('is run if execution completes successfully', () => {
+    execution.resume(123);
+    expect(thing).toEqual("ran at exit");
+  });
+
+  it('is run if execution is halted', () => {
+    execution.halt();
+    expect(thing).toEqual("ran at exit");
+  });
+
+  it('is run if execution errors', () => {
+    execution.throw(new Error("boom"));
+    expect(thing).toEqual("ran at exit");
+  });
+});

--- a/types/execute.test.ts
+++ b/types/execute.test.ts
@@ -20,6 +20,7 @@ execution = fork((execution: Execution<number>) => {
   execution.halt("optional reason");
   execution.halt();
   execution.throw(new Error('boom!'));
+  execution.atExit(() => {});
 });
 
 // $ExpectError


### PR DESCRIPTION
This is different from using `finally`, since promise chains will generally resolve in the next tick. Imagine for example that we want to clean up an event listener, then it would be very unfortunate if an event occurs in-between the fork finalizing and the finally hook being run.