### PR TITLE
Add monitor function which doesn't block parent from shutting down

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -13,6 +13,7 @@ declare module "effection" {
     halt(reason?: any): void;
     catch<R>(fn: (error: Error) => R): Promise<R>;
     finally(fn: () => void): Promise<any>;
+    monitor<T>(operation: Operation): Execution<T>;
   }
 
   export function fork<T>(operation: Operation): Execution<T>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -17,5 +17,7 @@ declare module "effection" {
 
   export function fork<T>(operation: Operation): Execution<T>;
 
+  export function monitor<T>(operation: Operation): Execution<T>;
+
   export function timeout(durationMillis: number): Operation;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,2 @@
 export { timeout } from './timeout';
-export { fork } from './fork';
+export { fork, monitor } from './fork';

--- a/tests/monitor.test.js
+++ b/tests/monitor.test.js
@@ -1,0 +1,81 @@
+/* global describe, beforeEach, it */
+/* eslint require-yield: 0 */
+/* eslint no-unreachable: 0 */
+
+import expect from 'expect';
+
+import { fork, monitor } from '../src/index';
+
+describe('monitor', () => {
+  describe('creates a monitor which does not prevent execution from finishing', () => {
+    let execution, one, two;
+
+    beforeEach(() => {
+      execution = fork(function() {
+        monitor(function*() {
+          yield cxt => one = cxt;
+        });
+
+        fork(function*() {
+          yield cxt => two = cxt;
+        });
+      });
+    });
+
+    describe('finishing forks', () => {
+      beforeEach(() => {
+        two.resume();
+      });
+
+      it('shuts down the monitor', () => {
+        expect(one.isHalted).toEqual(true);
+        expect(one.isBlocking).toEqual(false);
+
+        expect(two.isCompleted).toEqual(true);
+        expect(two.isBlocking).toEqual(false);
+      });
+
+      it('completes the top level exectution', () => {
+        expect(execution.isCompleted).toEqual(true);
+      });
+    });
+
+    describe('halting the top level context', () => {
+      beforeEach(() => {
+        execution.halt();
+      });
+
+      it('halts the monitor', () => {
+        expect(one.isHalted).toEqual(true);
+        expect(two.isHalted).toEqual(true);
+      });
+    });
+
+    describe('halting the monitor', () => {
+      beforeEach(() => {
+        one.halt();
+      });
+      it('does not cancel anything else', () => {
+        expect(execution.isWaiting).toEqual(true);
+        expect(two.isRunning).toEqual(true);
+      });
+    });
+
+    describe('throwing an error in the monitor', () => {
+      let boom;
+      beforeEach(() => {
+        boom = new Error('boom!');
+        one.throw(boom);
+      });
+
+      it('errors out the parent', () => {
+        expect(execution.isErrored).toEqual(true);
+        expect(execution.result).toEqual(boom);
+      });
+
+      it('has the error as its result', () => {
+        expect(execution.result).toEqual(boom);
+      });
+    });
+  });
+});

--- a/types/execute.test.ts
+++ b/types/execute.test.ts
@@ -20,6 +20,9 @@ execution = fork((execution: Execution<number>) => {
   execution.halt("optional reason");
   execution.halt();
   execution.throw(new Error('boom!'));
+  execution.monitor(function*() {
+    yield
+  });
 });
 
 // $ExpectError

--- a/types/monitor.test.ts
+++ b/types/monitor.test.ts
@@ -1,0 +1,26 @@
+import { Execution, Sequence, monitor } from 'effection';
+
+function* operation(): Sequence {}
+
+let execution: Execution;
+
+execution = monitor(operation);
+
+execution = monitor(operation());
+
+execution = monitor(Promise.resolve("hello world"));
+
+execution = monitor(function*() {});
+
+execution = monitor(undefined);
+
+execution = monitor((execution: Execution<number>) => {
+  execution.id;
+  execution.resume(10);
+  execution.halt("optional reason");
+  execution.halt();
+  execution.throw(new Error('boom!'));
+});
+
+// $ExpectError
+monitor(5);


### PR DESCRIPTION
This comes up time and again, where we want to have a fork, but do not want the fork to block the parent from shutting down. Where this is common is in the error monitor pattern that has emerged in bigtest-server. Hence the function name.

So for example:

``` javascript
  let errorMonitor = fork(function*() {
    let [error]: [Error] = yield on(child, "error");
    throw error;
  });
```

This is tricky because the error monitor will block the fork from shutting down. This is likely not what we want. Instead we want the monitor to shut down if the parent exits. To accomplish this today, we need to wrap the entire rest of the function in a try-finally.

``` javascript
  let errorMonitor = fork(function*() {
    let [error]: [Error] = yield on(child, "error");
    throw error;
  });

  try {
    ...
    yield
    ...
  } finally {
    errorMonitor.halt();
  }
```

This is both ugly and error prone. With the monitor function we can write this more naturally:

``` javascript
  monitor(function*() {
    let [error]: [Error] = yield on(child, "error");
    throw error;
  });
```