### PR TITLE
Implement `monitor` as operation

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -31,6 +31,8 @@ declare module "effection" {
 
   export function join(context: Context): Operation;
 
+  export function monitor(operation: Operation): Operation;
+
   export function timeout(durationMillis: number): Operation;
 
 

--- a/src/context.js
+++ b/src/context.js
@@ -13,19 +13,20 @@ export class ExecutionContext {
 
   get hasBlockingChildren() {
     for (let child of this.children) {
-      if (child.isBlocking) {
+      if (child.isBlocking && child.isRequired) {
         return true;
       }
     }
     return false;
   }
 
-  constructor(parent = undefined) {
+  constructor(parent = undefined, isRequired = true) {
     this.id = this.constructor.ids++;
     this.parent = parent;
     this.children = new Set();
     this.exitHooks = new Set();
     this.state = 'unstarted';
+    this.isRequired = isRequired;
     this.mailbox = { messages: new Set(), receivers: new Set() };
     this.resume = this.resume.bind(this);
     this.fail = this.fail.bind(this);
@@ -72,8 +73,8 @@ export class ExecutionContext {
     }
   }
 
-  spawn(operation) {
-    let child = new ExecutionContext(this);
+  spawn(operation, isRequired) {
+    let child = new ExecutionContext(this, isRequired);
     this.children.add(child);
     child.ensure(() => {
       this.children.delete(child);

--- a/src/control.js
+++ b/src/control.js
@@ -108,10 +108,10 @@ export const GeneratorControl = generator => ControlFunction.of(self => {
   resume();
 });
 
-export function fork(operation) {
+export function fork(operation, required = true) {
   return ({ resume, context } ) => {
     let parent = context.parent ? context.parent : context;
-    let child = parent.spawn(operation);
+    let child = parent.spawn(operation, required);
 
     child.ensure(() => {
       if (child.isErrored) {
@@ -121,6 +121,10 @@ export function fork(operation) {
 
     resume(child);
   };
+}
+
+export function monitor(operation) {
+  return fork(operation, false);
 }
 
 export function join(antecedent) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 export { timeout } from './timeout';
-export { fork, join } from './control';
+export { fork, join, monitor } from './control';
 export { any } from './pattern';
 export { send, receive } from './mailbox';
 

--- a/tests/monitor.test.js
+++ b/tests/monitor.test.js
@@ -1,0 +1,77 @@
+/* global describe, beforeEach, it */
+/* eslint require-yield: 0 */
+/* eslint no-unreachable: 0 */
+
+import expect from 'expect';
+
+import { main, fork, monitor } from '../src/index';
+
+describe('monitor', () => {
+  describe('creates a monitor which does not prevent execution from finishing', () => {
+    let execution, one, two;
+
+    beforeEach(() => {
+      execution = main(function*() {
+        yield monitor(ctl => one = ctl);
+
+        yield fork(ctl => two = ctl);
+      });
+    });
+
+    describe('finishing forks', () => {
+      beforeEach(() => {
+        two.resume();
+      });
+
+      it('shuts down the monitor', () => {
+        expect(one.context.isHalted).toEqual(true);
+        expect(one.context.isBlocking).toEqual(false);
+
+        expect(two.context.isCompleted).toEqual(true);
+        expect(two.context.isBlocking).toEqual(false);
+      });
+
+      it('completes the top level exectution', () => {
+        expect(execution.isCompleted).toEqual(true);
+      });
+    });
+
+    describe('halting the top level context', () => {
+      beforeEach(() => {
+        execution.halt();
+      });
+
+      it('halts the monitor', () => {
+        expect(one.context.isHalted).toEqual(true);
+        expect(two.context.isHalted).toEqual(true);
+      });
+    });
+
+    describe('halting the monitor', () => {
+      beforeEach(() => {
+        one.context.halt();
+      });
+      it('does not cancel anything else', () => {
+        expect(execution.isWaiting).toEqual(true);
+        expect(two.context.isRunning).toEqual(true);
+      });
+    });
+
+    describe('throwing an error in the monitor', () => {
+      let boom;
+      beforeEach(() => {
+        boom = new Error('boom!');
+        one.fail(boom);
+      });
+
+      it('errors out the parent', () => {
+        expect(execution.isErrored).toEqual(true);
+        expect(execution.result).toEqual(boom);
+      });
+
+      it('has the error as its result', () => {
+        expect(execution.result).toEqual(boom);
+      });
+    });
+  });
+});

--- a/types/monitor.test.ts
+++ b/types/monitor.test.ts
@@ -1,0 +1,22 @@
+import { Operation, Sequence, monitor } from 'effection';
+
+function* sequence(): Sequence {}
+
+let operation: Operation;
+
+operation = monitor(sequence);
+
+operation = monitor(sequence());
+
+operation = monitor(Promise.resolve("hello world"));
+
+operation = monitor(function*() {});
+
+operation = monitor(undefined);
+
+operation = monitor(({ resume }) => {
+  resume(10);
+});
+
+// $ExpectError
+monitor(5);


### PR DESCRIPTION
> This is an implementation of #58 based on operation based forks. Explanatory text is adapted below. Also note that this is an Addon pull request to #57, not master.

This comes up time and again, where we want to have a fork, but do not want the fork to block the parent from shutting down. Where this is common is in the error monitor pattern that has emerged in bigtest-server. Hence the function name.

So for example:

```ts
let errorMonitor = yield fork(function*() {
  let [error]: [Error] = yield on(child, "error");
  throw error;
});
```

This is tricky because the error monitor will block the fork from shutting down. This is likely not what we want. Instead we want the monitor to shut down if the parent exits. To accomplish this today, we need to wrap the entire rest of the function in a try-finally.

```ts
let errorMonitor = yield fork(function*() {
  let [error]: [Error] = yield on(child, "error");
  throw error;
});
ry {
  ...
  yield
  ...
} finally {
  errorMonitor.halt();
}
```

This is both ugly and error prone. With the monitor function we can write this more naturally:

```ts
yield monitor(function*() {
  let [error]: [Error] = yield on(child, "error");
  throw error;
});
```