### PR TITLE
Use more abstract typing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,11 +1,12 @@
 // TypeScript Version: 3.7
 declare module "effection" {
-  export type Operation = SequenceFn | Sequence | Promise<any> | Controller | undefined;
-  export type SequenceFn = () => Sequence;
+  export type Operation = OperationFn | Sequence | Promise<any> | Controller | undefined;
 
-  export type Controller = (controls: Controls) => void | (() => void);
+  type OperationFn = () => Operation;
 
-  export interface Sequence extends Generator<Operation, any, any> {}
+  type Controller = (controls: Controls) => void | (() => void);
+
+  interface Sequence extends Generator<Operation, any, any> {}
 
   export interface Context extends PromiseLike<any> {
     id: number;
@@ -18,7 +19,7 @@ declare module "effection" {
 
   export interface Controls {
     id: number;
-    resume(result: any): void;
+    resume(result?: any): void;
     fail(error: Error): void;
     ensure(hook: (context?: Context) => void): () => void;
     spawn(operation: Operation): Context;

--- a/types/execute.test.ts
+++ b/types/execute.test.ts
@@ -17,6 +17,7 @@ execution = main(undefined);
 execution = main(({ resume, fail, ensure, context }) => {
   context.id;
   resume(10);
+  resume();
   context.halt();
   ensure((context?: Context) => console.log('done'));
   fail(new Error('boom!'));

--- a/types/imports.test.ts
+++ b/types/imports.test.ts
@@ -1,7 +1,5 @@
 import {
   Operation,
-  Sequence,
-  SequenceFn,
   Context,
   fork,
   join,


### PR DESCRIPTION
As we use effection more, it's clear that it isn't really helpful when it comes to composability to think of anything other than `Operation`s. It actually adds complexity to think of a generator function as anything other than just another function that happens to return an operation.

This lets you compose normal functions with generators. So, for example, the callback for a childProcess supervisor takes a function that accepts a child and returns another operation:

```ts
type UseChild = (child: ChildProcess) => Operation;

let getPid: UseChild = child => ({ resume }) => resume(child.pid);

let awaitExit: UseChild = function*(child) {
  yield on(child, 'exit');
}
```

One uses a generator, but the other is a controller function, but they're both assignable to the abstract Operation constructor. It's not helpful to distinguish between or declare them as their concrete types, and in fact, it's probably harmful in that it interferes with the mental model.

This change normalizes against `Operation` as the fundamental unit of operation, and actually un-exports the concrete types. Where as before, you would declare your generator function to return a sequence, now it returns an Operation.

before

```ts
function* doSomething(arg: Arg): Sequence {

}
```

after

```ts
function* doSometing(arg: Arg): Operation {

}
```

This help re-enforce the idea that a generator is just another way to define a function that returns an operation.

finally, this fixes an oversight that sometimes you can resume without specifying a value.