### PR TITLE
Strictly define order of operations when halting a tree

### DIFF
--- a/src/control.js
+++ b/src/control.js
@@ -116,7 +116,7 @@ export function fork(operation) {
     let child = parent.spawn(operation, child => {
       if (child.isErrored) {
         parent.fail(child.result);
-      } else if (parent.requiredChildren.size === 0) {
+      } else if (parent.isWaiting && parent.requiredChildren.size === 0) {
         parent.resume();
       }
     });
@@ -133,10 +133,9 @@ export function monitor(operation) {
   return ({ resume, context } ) => {
     let parent = context.parent ? context.parent : context;
     let child = parent.spawn(operation, () => {
-
       if (child.isErrored) {
         parent.fail(child.result);
-      } else if (parent.requiredChildren.size === 0) {
+      } else if (parent.isWaiting && parent.requiredChildren.size === 0) {
         parent.resume();
       }
     });

--- a/tests/async.test.js
+++ b/tests/async.test.js
@@ -329,4 +329,27 @@ describe('Async executon', () => {
       });
     });
   });
+
+  describe('a parent halting a child', () => {
+    let root, wait;
+
+    beforeEach(() => {
+      root = main(function* root() {
+        let child = yield fork();
+
+        try {
+          return yield cxt => wait = cxt;
+        } finally {
+          child.halt();
+        }
+      });
+
+      wait.resume(5);
+    });
+
+    it('returns its own result result', () => {
+      expect(root.result).toEqual(5);
+    });
+  });
+
 });

--- a/tests/order-of-operations.test.js
+++ b/tests/order-of-operations.test.js
@@ -1,0 +1,116 @@
+/* global describe, beforeEach, it */
+/* eslint require-yield: 0 */
+/* eslint no-unreachable: 0 */
+
+import expect from 'expect';
+
+import { main, fork } from '../src/index';
+
+/**
+ * Tests are performed on a tree that looks like this:
+ *
+ * [A,
+ *   [B,
+ *     [D],
+ *     [E,
+ *       [H]]],
+ *   [C,
+ *     [F, G]]]
+ */
+
+describe('Order of Shutdown Operations', () => {
+
+  let Node, order;
+  beforeEach(() => {
+    order = [];
+
+    let self = ({ resume, context: { parent }}) => resume(parent);
+
+    Node = function* Node(name, operations = []) {
+      let context = yield self;
+      Node[name] = context;
+      context.ensure(() => order.push([name, context.state]));
+
+      for (let operation of operations) {
+        yield fork(operation);
+      }
+      yield;
+    };
+
+    main(
+      Node('A', [
+        Node('B', [
+          Node('D'),
+          Node('E', [ Node('H') ])
+        ]),
+
+        Node('C', [
+          Node('F'),
+          Node('G')
+        ])
+      ]));
+
+    for (let name of Object.keys(Node)) {
+      expect(Node[name]).toBeDefined();
+    }
+
+  });
+
+  describe('when `H` encounters an error', () => {
+    beforeEach(() => {
+      Node.H.fail(new Error('H failed'));
+    });
+
+    it('tears down the tree in reverse upwards order', () => {
+      expect(order).toEqual([
+        ['H', 'errored'],
+        ['E', 'errored'],
+        ['D', 'halted'],
+        ['B', 'errored'],
+        ['G', 'halted'],
+        ['F', 'halted'],
+        ['C', 'halted'],
+        ['A', 'errored']
+      ]);
+    });
+  });
+
+
+  describe('when the top of the tree is halted', () => {
+    beforeEach(() => {
+      Node.A.halt();
+    });
+
+    it('tears down the tree in reverse upwards order', () => {
+      expect(order).toEqual([
+        ['G', 'halted'],
+        ['F', 'halted'],
+        ['C', 'halted'],
+        ['H', 'halted'],
+        ['E', 'halted'],
+        ['D', 'halted'],
+        ['B', 'halted'],
+        ['A', 'halted']
+      ]);
+    });
+  });
+
+  describe('when an error occurs in the middle of the tree', () => {
+    beforeEach(() => {
+      Node.C.fail(new Error('`C` failed'));
+    });
+
+    it('tears down the tree in reverse upwards order', () => {
+      expect(order).toEqual([
+        ['G', 'halted'],
+        ['F', 'halted'],
+        ['C', 'errored'],
+        ['H', 'halted'],
+        ['E', 'halted'],
+        ['D', 'halted'],
+        ['B', 'halted'],
+        ['A', 'errored']
+      ]);
+    });
+  });
+});

--- a/tests/spawn.test.js
+++ b/tests/spawn.test.js
@@ -37,7 +37,7 @@ describe('spawning operations', () => {
       beforeEach(() => {
         reject(boom = new Error('boom!'));
       });
-      it('fails both the child and the parent', () => {
+      it('fails the child, but not the parent', () => {
         expect(child.isErrored).toEqual(true);
         expect(child.result).toEqual(boom);
         expect(context.isRunning).toEqual(true);
@@ -66,8 +66,9 @@ describe('spawning operations', () => {
       beforeEach(() => {
         context.resume('parent done');
       });
-      it('is still not finished until the child is finished', () => {
-        expect(context.isWaiting).toEqual(true);
+      it('makes it complete, which immediately halts the child', () => {
+        expect(context.state).toEqual('completed');
+        expect(child.state).toEqual('halted');
       });
       describe('and then resuming the child', () => {
         beforeEach(() => {


### PR DESCRIPTION
Motivation
----------

When converting fork to an operation, we changed the way that continuation and failure are reported up the tree to the parent of the operation. Instead of calling the `join()` method on the parent, we used the general "exit hook" mechanism to control the flow of the program. When a child was created, the parent added shutdown hooks to it that would handle the result of the child finishing and use that to pass control back to the parent.

The problem with this is that if one of your shutdown hooks has the responsibility of running other shutdown hooks, which could cause shutdowns, that run other shutdown hooks, you can zig and zag across different contexts and experience wildly different orders of shutdown and context settlement depending on how a context resolves (success, failure, cancellation, etc..)

In fact, we were observing this behavior, when shutdown hooks were running in different orders, we'd see vastly different results.

What we'd like to see however is a strict reverse-depth-order teardown so that whenever a portion of the tree is de-commissioned, nodes that can have dependencies on prior nodes are de-commissioned first.

For example, in the following tree:

(A,
  (B)
  (C))

As children, both `B`, and `C` can depend on A, and even though `B` and `C` are siblings, since `C` was created later in the computation, it is conceivable that it depends on `B`. The reverse is not (easily) true. Therefore, the order of destruction we want is `C` -> `B` -> `A`.

Approach
--------

We address this problem by splitting shutdown callbacks into two distinct categories. The first is the original mechanism, added by `ensure()`, and which now has _zero_ effect on the control flow of the application. The exit hooks added in this way are just a flat list of functions to run a single time when the context is finalized. Each hook in the list only operates within the single context, and is mainly just meant to be added from user-land to control runtime resources.

The second kind of hook is used exclusively for handing off control of the computation from the finalizing context. In other words, "the computation represented by this context is now complete, what happens next?" While exit hooks can be many, there can only be a single continuation hook, and if we think about it, this make sense. Like a normal function, it can do a great many things, call out to a number of other functions, but it can only return to a single place.

In summary, by placing these two callbacks into different worlds, we can guarantee that shutdown hooks are run in a very precise order, and that they cannot (without dedicated nefarious hackery) interfere with the continuation of the computation.

Implementation
--------------

This uses the simplest thing that could possibly work: leave the current teardown mechanism as-is, and introduce a single callback to a new context. This callback is aptly name "continue", and is invoked as the very last thing a context _ever does_.

Now, finalize can only every be invoked a single time, and has a very
strict structure.

1. record results
2. halt all children in reverse order
3. run all exit hooks in reverse order
4. finalize the promise.
4. continue.

New Guarantees:

- spawn: all spawned child contexts are destroyed before their parent context is finalized. There is no continuation by default, so it just goes away without having any effect on the parent. However, if the parent is halted at any point during its run, it will be halted immediately.
- monitor: In addition to spawn guarantees, any failed monitor raises failure in its parent
- fork: In addition to monitor guarantees. parent may not continue until completed (though it may spawn more operations).
- join: In addition to fork guarantees, parent may not run any operations until joined child is completed.

For further context:

https://github.com/thefrontside/effection.js/issues/70

Open Questions
--------------

- There is probably a way to model the internal continuations semi-monadically so that we don't have to store state like required   children and `waiting ` and what not on the context, and so that in   `monitor` and `fork` and other control functions, we don't have to   fiddle with that state, but instead allow the control function   itself to somehow pass control to the "next" thing, which naturally   unfolds the computation. If it sounds hand-wavy, it is, but until   that elegant solution is found, we can start with a hackier one.
- We will need some way to "re-direct" the continuation of a context   in the case of joining a fork. In other words, if we join a fork,   something else needs to happen when it continues, not what happens when it was originally conceived.