### PR TITLE
Use constructor name to determine if a function is a generator function

### DIFF
--- a/src/generator-function.js
+++ b/src/generator-function.js
@@ -1,5 +1,7 @@
 export function isGeneratorFunction(fn) {
-  return fn && fn.constructor && fn.constructor.name === 'GeneratorFunction';
+  return fn != null
+    && typeof fn.constructor === 'function'
+    && fn.constructor.name === 'GeneratorFunction';
 }
 
 export function isGenerator(value) {

--- a/src/generator-function.js
+++ b/src/generator-function.js
@@ -1,8 +1,5 @@
-const GeneratorFunction = (function*() {}).constructor;
-
-
 export function isGeneratorFunction(fn) {
-  return fn != null && Object.getPrototypeOf(fn) === GeneratorFunction.prototype;
+  return fn && fn.constructor && fn.constructor.name === 'GeneratorFunction';
 }
 
 export function isGenerator(value) {


### PR DESCRIPTION
If we are using a polyfill runtime for generators, the constructors might not be identical. Using the name is a bit hacky, but it's the best we got.