### PR TITLE
Catch errors thrown in ensure block

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "coveralls": "nyc report --reporter=text-lcov | coveralls",
     "build": "pack build",
     "test": "mocha --recursive -r ./tests/setup tests/**/*.test.js",
+    "mocha": "mocha --recursive -r ./tests/setup",
     "test:types": "dtslint types --localTs node_modules/typescript/lib --expectOnly",
     "lint": "eslint ./",
     "pack:publish": "pack build && cd pkg && npm publish $*"
@@ -28,6 +29,7 @@
     "@pika/plugin-standard-pkg": "0.3.16",
     "@types/mocha": "^5.2.6",
     "babel-eslint": "10.0.1",
+    "capture-console": "^1.0.1",
     "conditional-type-checks": "^1.0.5",
     "dtslint": "^2.0.2",
     "eslint": "5.16.0",

--- a/src/context.js
+++ b/src/context.js
@@ -135,7 +135,17 @@ Thanks!`);
     }
 
     for (let hook of [...this.exitHooks].reverse()) {
-      hook();
+      try {
+        hook();
+      } catch(e) {
+        /* eslint-disable no-console */
+        console.error(`
+CRITICAL ERROR: an exception was thrown in an exit handler, this might put
+Effection into an unknown state, and you should avoid this ever happening.
+Original error:`);
+        console.error(e);
+        /* eslint-enable no-console */
+      }
     }
 
     if (this.parent) {

--- a/tests/controller.test.js
+++ b/tests/controller.test.js
@@ -82,17 +82,4 @@ describe('Controlling execution', () => {
       expect(relinquish).toHaveBeenCalled();
     });
   });
-
-  describe('a release function that throws an error', () => {
-    beforeEach(() => {
-      relinquish = () => { throw new Error('this is a bug in the release control!'); };
-      main(function* () {
-        yield control;
-      });
-    });
-
-    it('throws that error when trying to resume execution', () => {
-      expect(() => resume()).toThrow(/this is a bug/);
-    });
-  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1152,6 +1152,14 @@ archy@^1.0.0:
   resolved "https://registry.yarnpkg.com/archy/-/archy-1.0.0.tgz#f9c8c13757cc1dd7bc379ac77b2c62a5c2868c40"
   integrity sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=
 
+argle@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/argle/-/argle-1.1.1.tgz#0cfe3bc032c36b2f48ba42b9c17f89f70607e994"
+  integrity sha1-DP47wDLDay9IukK5wX+J9wYH6ZQ=
+  dependencies:
+    lodash.isfunction "^3.0.8"
+    lodash.isnumber "^3.0.3"
+
 argparse@^1.0.7:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
@@ -1178,6 +1186,11 @@ array-find-index@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-find-index/-/array-find-index-1.0.2.tgz#df010aa1287e164bbda6f9723b0a96a1ec4187a1"
   integrity sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=
+
+array-uniq@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.2.tgz#5fcc373920775723cfd64d65c64bef53bf9eba6d"
+  integrity sha1-X8w3OSB3VyPP1k1lxkvvU7+eum0=
 
 array-unique@^0.3.2:
   version "0.3.2"
@@ -1388,6 +1401,15 @@ caniuse-lite@^1.0.30000999:
   version "1.0.30000999"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000999.tgz#427253a69ad7bea4aa8d8345687b8eec51ca0e43"
   integrity sha512-1CUyKyecPeksKwXZvYw0tEoaMCo/RwBlXmEtN5vVnabvO0KPd9RQLcaAuR9/1F+KDMv6esmOFWlsXuzDk+8rxg==
+
+capture-console@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/capture-console/-/capture-console-1.0.1.tgz#db63c39ac73239019badd7fbb10143eda380ff71"
+  integrity sha1-22PDmscyOQGbrdf7sQFD7aOA/3E=
+  dependencies:
+    argle "~1.1.1"
+    lodash.isfunction "~3.0.8"
+    randomstring "~1.1.5"
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -2930,6 +2952,16 @@ lodash.flattendeep@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
   integrity sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=
 
+lodash.isfunction@^3.0.8, lodash.isfunction@~3.0.8:
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz#06de25df4db327ac931981d1bdb067e5af68d051"
+  integrity sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==
+
+lodash.isnumber@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz#3ce76810c5928d03352301ac287317f11c0b1ffc"
+  integrity sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w=
+
 lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.3.0:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
@@ -3570,6 +3602,13 @@ qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
+
+randomstring@~1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/randomstring/-/randomstring-1.1.5.tgz#6df0628f75cbd5932930d9fe3ab4e956a18518c3"
+  integrity sha1-bfBij3XL1ZMpMNn+OrTpVqGFGMM=
+  dependencies:
+    array-uniq "1.0.2"
 
 react-is@^16.8.4:
   version "16.10.2"


### PR DESCRIPTION
Closes #78

If an error ever occurrs in an ensure block, then that is a serious problem. We should inform the user that this is not good by printing a huge nasty warning to the console.

However, if such a situation does occur, at least it should not leave the process tree in an inconsistent state. Other exit hooks should still run, and other processes should still shut down. Currently if such an error does occur, it will blow the stack, and cause finalization to stop
abrubtly. This is very much not good.

Here we're rescuing any such errors, printing them to the console, but crucially we are NOT re-raising them. This allows us to proceed with finalization, which will leave the process tree in a more consistent state.

It's worth noting though that such a situation really is very undesirable. The Rust language does a hard abort of the process with an error exit code if a destructor panics, we cannot do something similar in effection, since we want to run in browsers, and browsers cannot hard-exit.