### PR TITLE
Make typescript types generic

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,38 +1,38 @@
 // TypeScript Version: 3.7
 declare module "effection" {
-  export type Operation = OperationFn | Sequence | Promise<any> | Controller | undefined;
+  export type Operation<T = any> = undefined | OperationFn<T> | Sequence<T> | PromiseLike<T> | Controller<T>;
 
-  type OperationFn = () => Operation;
+  type OperationFn<T = any> = () => Operation<T>;
 
-  type Controller = (controls: Controls) => void | (() => void);
+  type Controller<T = any> = (controls: Controls<T>) => void | (() => void);
 
-  interface Sequence extends Generator<Operation, any, any> {}
+  interface Sequence<T = any> extends Generator<Operation<any>, T, any> {}
 
-  export interface Context extends PromiseLike<any> {
+  export interface Context<T = any> extends PromiseLike<T> {
     id: number;
-    parent?: Context;
+    parent?: Context<any>;
     result?: any;
     halt(reason?: any): void;
     catch<R>(fn: (error: Error) => R): Promise<R>;
-    finally(fn: () => void): Promise<any>;
+    finally(fn: () => void): Promise<undefined>;
   }
 
-  export interface Controls {
+  export interface Controls<T = any> {
     id: number;
-    resume(result?: any): void;
+    resume(result?: T): void;
     fail(error: Error): void;
-    ensure(hook: (context?: Context) => void): () => void;
-    spawn(operation: Operation): Context;
-    context: Context;
+    ensure(hook: (context?: Context<T>) => void): () => void;
+    spawn<C>(operation: Operation<C>): Context<C>;
+    context: Context<T>;
   }
 
-  export function main(operation: Operation): Context;
+  export function main<T>(operation: Operation<T>): Context<T>;
 
-  export function fork(operation: Operation): Operation;
+  export function fork<T>(operation: Operation<T>): Operation<Context<T>>;
 
-  export function join(context: Context): Operation;
+  export function join<T>(context: Context<T>): Operation<T>;
 
-  export function monitor(operation: Operation): Operation;
+  export function monitor<T>(operation: Operation<T>): Operation<T>;
 
-  export function timeout(durationMillis: number): Operation;
+  export function timeout(durationMillis: number): Operation<number>;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -34,5 +34,5 @@ declare module "effection" {
 
   export function monitor<T>(operation: Operation<T>): Operation<T>;
 
-  export function timeout(durationMillis: number): Operation<number>;
+  export function timeout(durationMillis: number): Operation<void>;
 }

--- a/src/timeout.js
+++ b/src/timeout.js
@@ -9,7 +9,7 @@
 */
 export function timeout(duration) {
   return ({ resume, ensure }) => {
-    let timeoutId = setTimeout(resume, duration);
+    let timeoutId = setTimeout(() => resume(), duration);
     ensure(() => clearTimeout(timeoutId));
   };
 }

--- a/types/generics.test.ts
+++ b/types/generics.test.ts
@@ -1,0 +1,31 @@
+import { Operation, Controller } from 'effection';
+
+function *randomNumber(): Operation<number> {
+  yield;
+  return 4;
+}
+
+function *main(): Operation<string> {
+  let result = yield randomNumber();
+
+  result += 1;
+
+  return `thing${result}`;
+}
+
+let controlFunction: Controller<number> = ({ resume }) => {
+  resume(123);
+}
+
+function *brokenGenerator(): Operation<number> {
+  yield;
+  // cannot return invalid type
+  // $ExpectError
+  return "number";
+}
+
+let brokenControlFunction: Controller<number> = ({ resume }) => {
+  // cannot resume with another type
+  // $ExpectError
+  resume("somestring");
+}

--- a/types/promise.test.ts
+++ b/types/promise.test.ts
@@ -18,4 +18,11 @@ async function someAsyncFunction() {
   someFork.then((value: number) => {}, (error) => {});
   someFork.catch((error: Error) => "string").then((some) => {});
   someFork.finally(() => "string").then((some) => {});
+
+  // promise has type of the generator function
+  // $ExpectError
+  let broken: string = await main(function*() {
+    yield
+    return 123;
+  });
 }


### PR DESCRIPTION
This way the result of an operation can be carried forward, which makes typechecking better. Adding these generic types doesn't make a huge difference, but at least it complains when we get the return value of a generator function wrong, which is nice.