### PR TITLE
Extract the much used `main` method into its own package.

### DIFF
--- a/packages/effection/package.json
+++ b/packages/effection/package.json
@@ -13,7 +13,7 @@
     "build": "pack build",
     "test": "mocha --recursive -r ./tests/setup tests/**/*.test.js",
     "mocha": "mocha --recursive -r ./tests/setup",
-    "test:types": "dtslint types --localTs node_modules/typescript/lib --expectOnly",
+    "test:types": "dtslint types --localTs ../../node_modules/typescript/lib --expectOnly",
     "lint": "eslint ./",
     "pack:publish": "pack build && cd pkg && npm publish $*"
   },

--- a/packages/node/.gitignore
+++ b/packages/node/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+yarn-error.log
+.node-version
+.cache
+dist

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -1,0 +1,16 @@
+# @effection/node
+
+Work in Node.js with Effection
+
+## Synopsis
+
+``` typescript
+import { timeout } from 'effection';
+import { main } from '@effection/node';
+
+main(function* sayHello() {
+  console.log('Hello World!');
+  yield timeout(2000);
+  console.log('Goodbye World!')
+});
+```

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "lint": "echo [skip @effection/node]",
     "test": "echo '[no-tests @effection/node]'",
+    "pack:publish": "npm publish $*",
     "prepack": "tsc --outdir dist --project tsconfig.dist.json --declaration --sourcemap --module commonjs"
   },
   "devDependencies": {

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@effection/node",
+  "version": "0.5.2",
+  "description": "Work in Node.js with Effection",
+  "main": "dist/index.js",
+  "typings": "dist/index.d.js",
+  "repository": "https://github.com/thefrontside/bigtest.git",
+  "author": "Frontside Engineering <engineering@frontside.io>",
+  "license": "MIT",
+  "files": ["dist/*", "README.md"],
+  "scripts": {
+    "lint": "echo [skip @effection/node]",
+    "test": "echo '[no-tests @effection/node]'",
+    "prepack": "tsc --outdir dist --project tsconfig.dist.json --declaration --sourcemap --module commonjs"
+  },
+  "devDependencies": {
+    "@types/node": "^12.7.11",
+    "typescript": "^3.7.0"
+  },
+  "peerDependencies": {
+    "effection": "^0.5.2"
+  },
+  "volta": {
+    "node": "12.16.0",
+    "yarn": "1.19.1"
+  }
+}

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -1,0 +1,21 @@
+import { main as effectionMain, Context, Operation } from 'effection';
+
+export function main<T>(operation: Operation<T>): Context<T> {
+  return effectionMain(({ context: mainContext, spawn }) => {
+    spawn(function* main() {
+      let interrupt = () => { mainContext.halt(); };
+      let debug = () => console.debug(mainContext.toString());
+      try {
+        process.on('SIGINT', interrupt);
+        process.on('SIGUSR1', debug);
+        return yield operation;
+      } catch(e) {
+        console.error(e);
+        process.exit(-1);
+      } finally {
+        process.off('SIGINT', interrupt);
+        process.off('SIGUSR1', debug);
+      }
+    });
+  });
+}

--- a/packages/node/tsconfig.dist.json
+++ b/packages/node/tsconfig.dist.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig",
+  "exclude": ["./test/*"]
+}

--- a/packages/node/tsconfig.json
+++ b/packages/node/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "moduleResolution": "node",
+    "noImplicitAny": true,
+    "typeRoots": [
+      "./node_modules/@types"
+    ],
+    "baseUrl": "."
+  },
+  "include": [
+    "src/**/*.ts",
+    "bin/*.ts",
+    "test/**/*.ts"
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1039,6 +1039,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.17.tgz#7a183163a9e6ff720d86502db23ba4aade5999b8"
   integrity sha512-gpNnRnZP3VWzzj5k3qrpRC6Rk3H/uclhAVo1aIvwzK5p5cOrs9yEyQ8H/HBsBY0u5rrWxXEiVPQ0dEB6pkjE8Q==
 
+"@types/node@^12.7.11":
+  version "12.12.29"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.29.tgz#46275f028b4e463b9ac5fefc1d08bc66cc193f25"
+  integrity sha512-yo8Qz0ygADGFptISDj3pOC9wXfln/5pQaN/ysDIzOaAWXt73cNHmtEC8zSO2Y+kse/txmwIAJzkYZ5fooaS5DQ==
+
 "@types/parsimmon@^1.3.0":
   version "1.10.1"
   resolved "https://registry.yarnpkg.com/@types/parsimmon/-/parsimmon-1.10.1.tgz#d46015ad91128fce06a1a688ab39a2516507f740"


### PR DESCRIPTION
> depends on #84 This PR should be re-targeted to `master` once that one is merged

Motivation
----------

When you're managing a node process, there are things that you almost always want to do: setup a SIGINT handler to interrupt the process, catch errors and log them to the console, and exit when appropriate with the proper code. The server package had a very handy main method that was used in several places via copy paste.

Approach
--------

This consolidates all of those main methods down into a single location that can be shared by all.