### PR TITLE
Allows contexts to escape to parent via return

### DIFF
--- a/packages/effection/src/index.js
+++ b/packages/effection/src/index.js
@@ -1,5 +1,7 @@
 export { timeout } from './timeout';
-export { fork, join, monitor } from './control';
+export { fork, join, spawn, spawn as monitor } from './control';
+
+export { ExecutionContext } from './context';
 
 import { ExecutionContext } from './context';
 

--- a/packages/effection/tests/context-return.test.js
+++ b/packages/effection/tests/context-return.test.js
@@ -1,0 +1,44 @@
+/* global describe, beforeEach, it */
+/* eslint require-yield: 0 */
+/* eslint no-unreachable: 0 */
+
+import expect from 'expect';
+
+import { main, fork, spawn } from '../src/index';
+
+describe('Returning an execution context', () => {
+  let execution, one, two, inner;
+
+  beforeEach(() => {
+    execution = main(function* outer() {
+      one = yield function*() {
+        inner = yield spawn();
+        return inner;
+      };
+      two = yield fork();
+    });
+  });
+
+  it('does not affect the state of the parent context', () => {
+    expect(execution.state).toEqual("waiting");
+    expect(two.state).toEqual("running");
+  });
+
+  it('does not halt the returned execution context when exiting the scope', () => {
+    expect(inner.state).toEqual("running");
+  });
+
+  it('resolves to the returned context', () => {
+    expect(one).toEqual(inner);
+  });
+
+  describe('halting the context into which it was returned', () => {
+    beforeEach(() => {
+      execution.halt();
+    });
+
+    it('also halts the returned context', () => {
+      expect(inner.state).toEqual("halted");
+    });
+  });
+});

--- a/packages/effection/tests/execution.test.js
+++ b/packages/effection/tests/execution.test.js
@@ -1,6 +1,6 @@
 import expect from 'expect';
 import mock from 'jest-mock';
-import { main, join, fork } from '../src/index';
+import { main, join } from '../src/index';
 
 describe('execution', () => {
 
@@ -73,42 +73,6 @@ describe('execution', () => {
       });
       it('is errored', () => {
         expect(exec.isErrored).toBe(true);
-      });
-    });
-  });
-
-  describe('forking from a process', () => {
-    let exec, resume, fail;
-
-    beforeEach(() => {
-      exec = main(fork(context => ({ resume, fail } = context)));
-    });
-
-    it('makes the external process waiting and blocking', () => {
-      expect(exec.isBlocking).toBe(true);
-      expect(exec.isWaiting).toBe(true);
-    });
-
-    describe('resuming the forked process', () => {
-      beforeEach(() => {
-        resume();
-      });
-      it('completes the external process', () => {
-        expect(exec.isCompleted).toBe(true);
-      });
-    });
-
-    describe('failing the forked process', () => {
-      beforeEach(() => {
-        fail(new Error('boom!'));
-      });
-
-      it('fails the process', () => {
-        expect(exec.isErrored).toBe(true);
-      });
-      it('has the error as the result', () => {
-        expect(exec.result).toBeDefined();
-        expect(exec.result.message).toEqual('boom!');
       });
     });
   });

--- a/packages/effection/tests/order-of-operations.test.js
+++ b/packages/effection/tests/order-of-operations.test.js
@@ -24,17 +24,15 @@ describe('Order of Shutdown Operations', () => {
   beforeEach(() => {
     order = [];
 
-    let self = ({ resume, context: { parent }}) => resume(parent);
+    Node = function Node(name, operations = []) {
+      return ({ ensure, context, spawn }) => {
+        Node[name] = context;
+        ensure(() => order.push([name, context.state]));
 
-    Node = function* Node(name, operations = []) {
-      let context = yield self;
-      Node[name] = context;
-      context.ensure(() => order.push([name, context.state]));
-
-      for (let operation of operations) {
-        yield fork(operation);
-      }
-      yield;
+        for (let operation of operations) {
+          spawn(fork(operation));
+        }
+      };
     };
 
     main(

--- a/packages/effection/tests/spawn.test.js
+++ b/packages/effection/tests/spawn.test.js
@@ -37,10 +37,11 @@ describe('spawning operations', () => {
       beforeEach(() => {
         reject(boom = new Error('boom!'));
       });
-      it('fails the child, but not the parent', () => {
+      it('fails the child, and also the parent', () => {
         expect(child.isErrored).toEqual(true);
         expect(child.result).toEqual(boom);
-        expect(context.isRunning).toEqual(true);
+        expect(context.isErrored).toEqual(true);
+        expect(context.result).toEqual(boom);
       });
     });
 


### PR DESCRIPTION
When a context returns another context, that context is kept alive. Meaning that unlike other children, it won't be halted when the context exits, it is then linked to the parent. This provides a desired escape hatch to allowing contexts escape the scope in which they were created.

Initially we used the `suspend` pattern for this purpose, but as documented in #86, this pattern does not compose well, and its behaviour is confusing at times.

In the future, we might extend this functionality with what we have dubbed resources, where a resource basically bundles some JavaScript object, and an associated context. This PR does not implement such a feature yet.

This PR also makes a few other changes which were necessary or convenient for implementing this feature:

- execution contexts now track whether they are required. This simplifies things, since we want to preserve whether they are required when they are returned

- execution contexts are not initialized with a parent, but rather they can be linked to another context through `link` and `unlink`. This allows for more flexibility

- linked children always propagate errors to their parents. Instead of this being part of the functionality of spawn and fork. This does require some trickery to make generator work, but I think it is worth it.

- `monitor` has been renamed to `spawn` (an alias is retained for now), because it does not add any functionality on top of `context.spawn`.

- It is currently no longer supported to use a `fork` or `spawn` as the top level operation. Because it hurts my brain and I can't figure out what sensible behaviour actually should be.