### PR TITLE
Implement support for resources 

### DIFF
--- a/packages/effection/package.json
+++ b/packages/effection/package.json
@@ -14,7 +14,7 @@
     "test": "mocha --recursive -r ./tests/setup tests/**/*.test.js",
     "mocha": "mocha --recursive -r ./tests/setup",
     "test:types": "dtslint types --localTs ../../node_modules/typescript/lib --expectOnly",
-    "lint": "eslint ./",
+    "lint": "eslint '{src,tests}/**/*.js'",
     "pack:publish": "pack build && cd pkg && npm publish $*"
   },
   "devDependencies": {

--- a/packages/effection/src/context.js
+++ b/packages/effection/src/context.js
@@ -22,6 +22,7 @@ export class ExecutionContext {
     this.resume = this.resume.bind(this);
     this.fail = this.fail.bind(this);
     this.spawn = this.spawn.bind(this);
+    this.fork = this.fork.bind(this);
     this.ensure = this.ensure.bind(this);
   }
 
@@ -64,8 +65,15 @@ export class ExecutionContext {
     }
   }
 
-  spawn(operation, required = false) {
-    let child = new ExecutionContext(required);
+  spawn(operation) {
+    let child = new ExecutionContext(false);
+    this.link(child);
+    child.enter(operation);
+    return child;
+  }
+
+  fork(operation) {
+    let child = new ExecutionContext(true);
     this.link(child);
     child.enter(operation);
     return child;
@@ -88,8 +96,8 @@ export class ExecutionContext {
       this.operation = operation;
       this.state = 'running';
 
-      let { resume, fail, ensure, spawn } = this;
-      controller.call({ resume, fail, ensure, spawn, context: this });
+      let { resume, fail, ensure, spawn, fork } = this;
+      controller.call({ resume, fail, ensure, spawn, fork, context: this });
     } else {
       throw new Error(`
 Tried to call #enter() on a Context that has already been finalized. This

--- a/packages/effection/src/control.js
+++ b/packages/effection/src/control.js
@@ -63,17 +63,13 @@ export const GeneratorFunctionControl = sequence => ControlFunction.of((...args)
 
 class GeneratorExecutionContext extends ExecutionContext {
   constructor(parentControls, generator) {
-    super(true);
+    super();
     this.generator = generator;
     this.parentControls = parentControls;
-    this.ensure(() => {
-      this.generator.return();
-      parentControls.resume(this.result);
-    });
+    this.ensure(() => this.generator.return());
   }
 
   enter() {
-    super.enter(undefined);
     this.advance(() => this.generator.next());
   }
 
@@ -81,7 +77,8 @@ class GeneratorExecutionContext extends ExecutionContext {
     try {
       let next = getNext();
       if (next.done) {
-        this.resume(next.value);
+        this.resume();
+        this.parentControls.resume(next.value);
       } else {
         this.fork(next.value);
       }

--- a/packages/effection/src/control.js
+++ b/packages/effection/src/control.js
@@ -83,7 +83,7 @@ class GeneratorExecutionContext extends ExecutionContext {
       if (next.done) {
         this.resume(next.value);
       } else {
-        this.spawn(next.value, true);
+        this.fork(next.value);
       }
     } catch (error) {
       this.fail(error);
@@ -126,8 +126,8 @@ export const GeneratorControl = generator => ControlFunction.of(self => {
 });
 
 export function fork(operation) {
-  return ({ resume, spawn } ) => {
-    resume(spawn(operation, true));
+  return ({ resume, fork } ) => {
+    resume(fork(operation));
   };
 }
 

--- a/packages/effection/src/control.js
+++ b/packages/effection/src/control.js
@@ -70,6 +70,7 @@ class GeneratorExecutionContext extends ExecutionContext {
   }
 
   enter() {
+    super.enter(undefined);
     this.advance(() => this.generator.next());
   }
 

--- a/packages/effection/src/index.js
+++ b/packages/effection/src/index.js
@@ -1,5 +1,7 @@
 export { timeout } from './timeout';
-export { fork, join, monitor } from './control';
+export { fork, join, spawn, spawn as monitor } from './control';
+
+export { ExecutionContext } from './context';
 
 import { ExecutionContext } from './context';
 

--- a/packages/effection/src/index.js
+++ b/packages/effection/src/index.js
@@ -2,6 +2,7 @@ export { timeout } from './timeout';
 export { fork, join, spawn, spawn as monitor } from './control';
 
 export { ExecutionContext } from './context';
+export { resource, contextOf } from './resource';
 
 import { ExecutionContext } from './context';
 

--- a/packages/effection/src/index.js
+++ b/packages/effection/src/index.js
@@ -7,7 +7,7 @@ export { resource, contextOf } from './resource';
 import { ExecutionContext } from './context';
 
 export function main(operation) {
-  let top = new ExecutionContext({ allowContextReturn: false });
+  let top = new ExecutionContext({ blockOnReturnedContext: true });
   top.enter(operation);
   return top;
 }

--- a/packages/effection/src/index.js
+++ b/packages/effection/src/index.js
@@ -7,7 +7,7 @@ export { resource, contextOf } from './resource';
 import { ExecutionContext } from './context';
 
 export function main(operation) {
-  let top = new ExecutionContext();
+  let top = new ExecutionContext({ allowContextReturn: false });
   top.enter(operation);
   return top;
 }

--- a/packages/effection/src/resource.js
+++ b/packages/effection/src/resource.js
@@ -12,7 +12,7 @@ export function contextOf(resource) {
 
 export function resource(object, operation) {
   return ({ resume, context } ) => {
-    let child = new ExecutionContext();
+    let child = new ExecutionContext({ isRequired: false, allowContextReturn: false });
     context.link(child);
     child.enter(operation);
     Object.defineProperty(object, symbol, {

--- a/packages/effection/src/resource.js
+++ b/packages/effection/src/resource.js
@@ -1,0 +1,26 @@
+import { ExecutionContext } from './context';
+
+let symbol = Symbol("resource");
+
+export function contextOf(resource) {
+  if(resource instanceof ExecutionContext) {
+    return resource;
+  } else if(typeof(resource) === "object" || typeof(resource) === "function") {
+    return resource[symbol];
+  }
+}
+
+export function resource(object, operation) {
+  return ({ resume, context } ) => {
+    let child = new ExecutionContext();
+    context.link(child);
+    child.enter(operation);
+    Object.defineProperty(object, symbol, {
+      value: child,
+      configurable: true,
+      enumerable: false,
+      writable: false,
+    });
+    resume(object);
+  };
+}

--- a/packages/effection/src/resource.js
+++ b/packages/effection/src/resource.js
@@ -12,7 +12,7 @@ export function contextOf(resource) {
 
 export function resource(object, operation) {
   return ({ resume, context } ) => {
-    let child = new ExecutionContext({ isRequired: false, allowContextReturn: false });
+    let child = new ExecutionContext({ isRequired: false, blockOnReturnedContext: true });
     context.link(child);
     child.enter(operation);
     Object.defineProperty(object, symbol, {

--- a/packages/effection/tests/context-return.test.js
+++ b/packages/effection/tests/context-return.test.js
@@ -9,36 +9,65 @@ import { main, fork, spawn } from '../src/index';
 describe('Returning an execution context', () => {
   let execution, one, two, inner;
 
-  beforeEach(() => {
-    execution = main(function* outer() {
-      one = yield function*() {
-        inner = yield spawn();
-        return inner;
-      };
-      two = yield fork();
-    });
-  });
-
-  it('does not affect the state of the parent context', () => {
-    expect(execution.state).toEqual("waiting");
-    expect(two.state).toEqual("running");
-  });
-
-  it('does not halt the returned execution context when exiting the scope', () => {
-    expect(inner.state).toEqual("running");
-  });
-
-  it('resolves to the returned context', () => {
-    expect(one).toEqual(inner);
-  });
-
-  describe('halting the context into which it was returned', () => {
+  describe('with a regular return', () => {
     beforeEach(() => {
-      execution.halt();
+      execution = main(function* outer() {
+        one = yield function*() {
+          inner = yield spawn();
+          return inner;
+        };
+        two = yield fork();
+      });
     });
 
-    it('also halts the returned context', () => {
-      expect(inner.state).toEqual("halted");
+    it('does not affect the state of the parent context', () => {
+      expect(execution.state).toEqual("waiting");
+      expect(two.state).toEqual("running");
+    });
+
+    it('does not halt the returned execution context when exiting the scope', () => {
+      expect(inner.state).toEqual("running");
+    });
+
+    it('resolves to the returned context', () => {
+      expect(one).toEqual(inner);
+    });
+
+    describe('halting the context into which it was returned', () => {
+      beforeEach(() => {
+        execution.halt();
+      });
+
+      it('also halts the returned context', () => {
+        expect(inner.state).toEqual("halted");
+      });
+    });
+  });
+
+  describe('with a top level return', () => {
+    beforeEach(() => {
+      execution = main(function* outer() {
+        inner = yield fork();
+        return inner;
+      });
+    });
+
+    it('keeps the top scope blocking', () => {
+      expect(execution.isBlocking).toEqual(true);
+    });
+
+    it('does not halt the returned execution context when exiting the scope', () => {
+      expect(inner.state).toEqual("running");
+    });
+
+    describe('halting the top scope', () => {
+      beforeEach(() => {
+        execution.halt();
+      });
+
+      it('also halts the returned context', () => {
+        expect(inner.state).toEqual("halted");
+      });
     });
   });
 });

--- a/packages/effection/tests/context-return.test.js
+++ b/packages/effection/tests/context-return.test.js
@@ -1,0 +1,44 @@
+/* global describe, beforeEach, it */
+/* eslint require-yield: 0 */
+/* eslint no-unreachable: 0 */
+
+import expect from 'expect';
+
+import { main, fork, spawn } from '../src/index';
+
+describe('Returning an execution context', () => {
+  let execution, one, two, inner;
+
+  beforeEach(() => {
+    execution = main(function* outer() {
+      one = yield function*() {
+        inner = yield spawn();
+        return inner;
+      };
+      two = yield fork();
+    });
+  });
+
+  it('does not affect the state of the parent context', () => {
+    expect(execution.state).toEqual("waiting");
+    expect(two.state).toEqual("running");
+  });
+
+  it('does not halt the returned execution context when exiting the scope', () => {
+    expect(inner.state).toEqual("running");
+  });
+
+  it('resolves to the returned context', () => {
+    expect(one).toEqual(inner);
+  });
+
+  describe('halting the context into which it was returned', () => {
+    beforeEach(() => {
+      execution.halt();
+    });
+
+    it('also halts the returned context', () => {
+      expect(inner.state).toEqual("halted");
+    });
+  });
+});

--- a/packages/effection/tests/execution.test.js
+++ b/packages/effection/tests/execution.test.js
@@ -1,6 +1,6 @@
 import expect from 'expect';
 import mock from 'jest-mock';
-import { main, join, fork } from '../src/index';
+import { main, join, fork, spawn } from '../src/index';
 
 describe('execution', () => {
 
@@ -99,6 +99,42 @@ describe('execution', () => {
     });
 
     describe('failing the forked process', () => {
+      beforeEach(() => {
+        fail(new Error('boom!'));
+      });
+
+      it('fails the process', () => {
+        expect(exec.isErrored).toBe(true);
+      });
+      it('has the error as the result', () => {
+        expect(exec.result).toBeDefined();
+        expect(exec.result.message).toEqual('boom!');
+      });
+    });
+  });
+
+  describe('spawning from a process', () => {
+    let exec, resume, fail;
+
+    beforeEach(() => {
+      exec = main(spawn(context => ({ resume, fail } = context)));
+    });
+
+    it('makes the external process waiting and blocking', () => {
+      expect(exec.isBlocking).toBe(true);
+      expect(exec.isWaiting).toBe(true);
+    });
+
+    describe('resuming the spawned process', () => {
+      beforeEach(() => {
+        resume();
+      });
+      it('completes the external process', () => {
+        expect(exec.isCompleted).toBe(true);
+      });
+    });
+
+    describe('failing the spawned process', () => {
       beforeEach(() => {
         fail(new Error('boom!'));
       });

--- a/packages/effection/tests/execution.test.js
+++ b/packages/effection/tests/execution.test.js
@@ -1,6 +1,6 @@
 import expect from 'expect';
 import mock from 'jest-mock';
-import { main, join } from '../src/index';
+import { main, join, fork } from '../src/index';
 
 describe('execution', () => {
 
@@ -73,6 +73,42 @@ describe('execution', () => {
       });
       it('is errored', () => {
         expect(exec.isErrored).toBe(true);
+      });
+    });
+  });
+
+  describe('forking from a process', () => {
+    let exec, resume, fail;
+
+    beforeEach(() => {
+      exec = main(fork(context => ({ resume, fail } = context)));
+    });
+
+    it('makes the external process waiting and blocking', () => {
+      expect(exec.isBlocking).toBe(true);
+      expect(exec.isWaiting).toBe(true);
+    });
+
+    describe('resuming the forked process', () => {
+      beforeEach(() => {
+        resume();
+      });
+      it('completes the external process', () => {
+        expect(exec.isCompleted).toBe(true);
+      });
+    });
+
+    describe('failing the forked process', () => {
+      beforeEach(() => {
+        fail(new Error('boom!'));
+      });
+
+      it('fails the process', () => {
+        expect(exec.isErrored).toBe(true);
+      });
+      it('has the error as the result', () => {
+        expect(exec.result).toBeDefined();
+        expect(exec.result.message).toEqual('boom!');
       });
     });
   });

--- a/packages/effection/tests/execution.test.js
+++ b/packages/effection/tests/execution.test.js
@@ -1,6 +1,6 @@
 import expect from 'expect';
 import mock from 'jest-mock';
-import { main, join, fork } from '../src/index';
+import { main, join } from '../src/index';
 
 describe('execution', () => {
 
@@ -73,42 +73,6 @@ describe('execution', () => {
       });
       it('is errored', () => {
         expect(exec.isErrored).toBe(true);
-      });
-    });
-  });
-
-  describe('forking from a process', () => {
-    let exec, resume, fail;
-
-    beforeEach(() => {
-      exec = main(fork(context => ({ resume, fail } = context)));
-    });
-
-    it('makes the external process waiting and blocking', () => {
-      expect(exec.isBlocking).toBe(true);
-      expect(exec.isWaiting).toBe(true);
-    });
-
-    describe('resuming the forked process', () => {
-      beforeEach(() => {
-        resume();
-      });
-      it('completes the external process', () => {
-        expect(exec.isCompleted).toBe(true);
-      });
-    });
-
-    describe('failing the forked process', () => {
-      beforeEach(() => {
-        fail(new Error('boom!'));
-      });
-
-      it('fails the process', () => {
-        expect(exec.isErrored).toBe(true);
-      });
-      it('has the error as the result', () => {
-        expect(exec.result).toBeDefined();
-        expect(exec.result.message).toEqual('boom!');
       });
     });
   });

--- a/packages/effection/tests/order-of-operations.test.js
+++ b/packages/effection/tests/order-of-operations.test.js
@@ -24,17 +24,15 @@ describe('Order of Shutdown Operations', () => {
   beforeEach(() => {
     order = [];
 
-    let self = ({ resume, context: { parent }}) => resume(parent);
+    Node = function Node(name, operations = []) {
+      return ({ ensure, context, spawn }) => {
+        Node[name] = context;
+        ensure(() => order.push([name, context.state]));
 
-    Node = function* Node(name, operations = []) {
-      let context = yield self;
-      Node[name] = context;
-      context.ensure(() => order.push([name, context.state]));
-
-      for (let operation of operations) {
-        yield fork(operation);
-      }
-      yield;
+        for (let operation of operations) {
+          spawn(fork(operation));
+        }
+      };
     };
 
     main(

--- a/packages/effection/tests/resources.test.js
+++ b/packages/effection/tests/resources.test.js
@@ -9,50 +9,102 @@ import { main, fork, contextOf, resource } from '../src/index';
 describe('Returning resources', () => {
   let execution, one, two, object, value, resume;
 
-  beforeEach(() => {
-    execution = main(function* outer() {
-      one = yield function* one() {
-        object = { hello: "world" };
-        return yield resource(object, function* resource() {
-          yield (ctl) => resume = ctl.resume;
-          value = 123;
-        });
-      };
-      two = yield fork();
-    });
-  });
-
-  it('does not affect the state of the parent context', () => {
-    expect(execution.state).toEqual("waiting");
-    expect(two.state).toEqual("running");
-  });
-
-  it('does not halt the returned resource when exiting the scope', () => {
-    expect(contextOf(object).state).toEqual("running");
-  });
-
-  it('resolves to the returned object', () => {
-    expect(one).toEqual(object);
-  });
-
-  describe('halting the context into which it was returned', () => {
+  describe('with regular resource', () => {
     beforeEach(() => {
-      execution.halt();
+      execution = main(function* outer() {
+        one = yield function* one() {
+          object = { hello: "world" };
+          return yield resource(object, function* resource() {
+            yield (ctl) => resume = ctl.resume;
+            value = 123;
+          });
+        };
+        two = yield fork();
+      });
     });
 
-    it('also halts the returned resource', () => {
-      expect(contextOf(object).state).toEqual("halted");
+    it('does not affect the state of the parent context', () => {
+      expect(execution.state).toEqual("waiting");
+      expect(two.state).toEqual("running");
+    });
+
+    it('does not halt the returned resource when exiting the scope', () => {
+      expect(contextOf(object).state).toEqual("running");
+    });
+
+    it('resolves to the returned object', () => {
+      expect(one).toEqual(object);
+    });
+
+    describe('halting the context into which it was returned', () => {
+      beforeEach(() => {
+        execution.halt();
+      });
+
+      it('also halts the returned resource', () => {
+        expect(contextOf(object).state).toEqual("halted");
+      });
+    });
+
+    describe('resuming the resource', () => {
+      beforeEach(() => {
+        resume();
+      });
+
+      it('completes the resource', () => {
+        expect(contextOf(object).state).toEqual("completed");
+        expect(value).toEqual(123);
+      });
     });
   });
 
-  describe('resuming the resource', () => {
+  describe('with context returning resource', () => {
     beforeEach(() => {
-      resume();
+      execution = main(function* outer() {
+        one = yield function* one() {
+          object = { hello: "world" };
+          return yield resource(object, function* resource() {
+            return yield fork((ctl) => {
+              resume = ctl.resume;
+            });
+          });
+        };
+        two = yield fork();
+      });
     });
 
-    it('completes the resource', () => {
-      expect(contextOf(object).state).toEqual("completed");
-      expect(value).toEqual(123);
+    it('does not affect the state of the parent context', () => {
+      expect(execution.state).toEqual("waiting");
+      expect(two.state).toEqual("running");
+    });
+
+    it('does not halt the returned resource when exiting the scope', () => {
+      expect(contextOf(object).state).toEqual("waiting");
+    });
+
+    it('resolves to the returned object', () => {
+      expect(one).toEqual(object);
+    });
+
+    describe('halting the context into which it was returned', () => {
+      beforeEach(() => {
+        execution.halt();
+      });
+
+      it('also halts the returned resource', () => {
+        expect(contextOf(object).state).toEqual("halted");
+      });
+    });
+
+    describe('resuming the resource', () => {
+      beforeEach(() => {
+        resume();
+      });
+
+      it('completes the resource', () => {
+        expect(contextOf(object).state).toEqual("completed");
+        expect(value).toEqual(123);
+      });
     });
   });
 });

--- a/packages/effection/tests/resources.test.js
+++ b/packages/effection/tests/resources.test.js
@@ -1,0 +1,58 @@
+/* global describe, beforeEach, it */
+/* eslint require-yield: 0 */
+/* eslint no-unreachable: 0 */
+
+import expect from 'expect';
+
+import { main, fork, contextOf, resource } from '../src/index';
+
+describe('Returning resources', () => {
+  let execution, one, two, object, value, resume;
+
+  beforeEach(() => {
+    execution = main(function* outer() {
+      one = yield function* one() {
+        object = { hello: "world" };
+        return yield resource(object, function* resource() {
+          yield (ctl) => resume = ctl.resume;
+          value = 123;
+        });
+      };
+      two = yield fork();
+    });
+  });
+
+  it('does not affect the state of the parent context', () => {
+    expect(execution.state).toEqual("waiting");
+    expect(two.state).toEqual("running");
+  });
+
+  it('does not halt the returned resource when exiting the scope', () => {
+    expect(contextOf(object).state).toEqual("running");
+  });
+
+  it('resolves to the returned object', () => {
+    expect(one).toEqual(object);
+  });
+
+  describe('halting the context into which it was returned', () => {
+    beforeEach(() => {
+      execution.halt();
+    });
+
+    it('also halts the returned resource', () => {
+      expect(contextOf(object).state).toEqual("halted");
+    });
+  });
+
+  describe('resuming the resource', () => {
+    beforeEach(() => {
+      resume();
+    });
+
+    it('completes the resource', () => {
+      expect(contextOf(object).state).toEqual("completed");
+      expect(value).toEqual(123);
+    });
+  });
+});

--- a/packages/effection/tests/spawn.test.js
+++ b/packages/effection/tests/spawn.test.js
@@ -37,10 +37,11 @@ describe('spawning operations', () => {
       beforeEach(() => {
         reject(boom = new Error('boom!'));
       });
-      it('fails the child, but not the parent', () => {
+      it('fails the child, and also the parent', () => {
         expect(child.isErrored).toEqual(true);
         expect(child.result).toEqual(boom);
-        expect(context.isRunning).toEqual(true);
+        expect(context.isErrored).toEqual(true);
+        expect(context.result).toEqual(boom);
       });
     });
 

--- a/packages/effection/types/index.d.ts
+++ b/packages/effection/types/index.d.ts
@@ -32,7 +32,13 @@ declare module "effection" {
 
   export function join<T>(context: Context<T>): Operation<T>;
 
+  export function spawn<T>(operation: Operation<T>): Operation<T>;
+
+  export function resource<T extends Object>(object: T, operation: Operation<void>): Operation<T>;
+
   export function monitor<T>(operation: Operation<T>): Operation<T>;
 
   export function timeout(durationMillis: number): Operation<void>;
+
+  export function contextOf(object: Object): Context<any> | undefined;
 }

--- a/packages/effection/types/index.d.ts
+++ b/packages/effection/types/index.d.ts
@@ -23,6 +23,7 @@ declare module "effection" {
     fail(error: Error): void;
     ensure(hook: (context?: Context<T>) => void): () => void;
     spawn<C>(operation: Operation<C>): Context<C>;
+    fork<C>(operation: Operation<C>): Context<C>;
     context: Context<T>;
   }
 


### PR DESCRIPTION
A resource ties an execution context to an object. This allows an object to be passed around between contexts while retaining an associated context. This context is "kept alive" as long as the object's scope is alive. If the object is returned out of the current scope, the context is hoisted to the parent scope along with the object. This allows an escape hatch from contexts being local to where they were created and makes it possible to implement the RAII pattern.