### PR TITLE
Update README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 [![npm](https://img.shields.io/npm/v/effection.svg)](https://www.npmjs.com/package/effection)
-[![bundle size (minified +
-gzip)](https://badgen.net/bundlephobia/minzip/effection)](https://bundlephobia.com/result?p=effection)
-[![CircleCI](https://circleci.com/gh/cowboyd/effection.js.svg?style=shield)](https://circleci.com/gh/cowboyd/effection.js)
+[![bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/effection)](https://bundlephobia.com/result?p=effection)
+[![CircleCI](https://circleci.com/gh/thefrontside/effection.js.svg?style=svg)](https://circleci.com/gh/thefrontside/effection.js)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Created by The Frontside](https://img.shields.io/badge/created%20by-frontside.io-blue.svg)](https://frontside.io)
+[![Created by Frontside](https://img.shields.io/badge/created%20by-frontside.io-blue.svg)](https://frontside.com)
 [![Chat on Discord](https://img.shields.io/discord/700803887132704931?Label=Discord)](https://discord.gg/Ug5nWH8)
 
 # effection


### PR DESCRIPTION
## Approach
- Changed Frontside link to frontside.com
- Changed bundle size badge from badgen.net to shields.io for consistency
- Updated circleci badge source to fetch from `thefrontside` github org and not `cowboyd`

## Test
![Screen Shot 2020-04-21 at 10 18 49 AM](https://user-images.githubusercontent.com/29791650/79876830-857d6f00-83b9-11ea-902d-0fe90e0a4e02.png)
