### PR TITLE
Don't crash when an operation returns a null value

### DIFF
--- a/packages/effection/src/resource.js
+++ b/packages/effection/src/resource.js
@@ -5,7 +5,7 @@ let symbol = Symbol("resource");
 export function contextOf(resource) {
   if(resource instanceof ExecutionContext) {
     return resource;
-  } else if(typeof(resource) === "object" || typeof(resource) === "function") {
+  } else if(resource != null) {
     return resource[symbol];
   }
 }

--- a/packages/effection/tests/resources.test.js
+++ b/packages/effection/tests/resources.test.js
@@ -107,4 +107,16 @@ describe('Returning resources', () => {
       });
     });
   });
+
+  describe('null operations', () => {
+    beforeEach(() => {
+      return execution = main(function*() {
+        yield Promise.resolve(null);
+      });
+    });
+    it('completes', () => {
+      expect(execution.state).toEqual('completed');
+    });
+  });
+
 });


### PR DESCRIPTION
We need to check for resources on return values of operations in order to link them to the parent context. To do this, we check that the object can receive property access. However, `typeof null` is actually `"object"`.

This adjusts the check to cover both undefined and null (as well as any other object type)