### PR TITLE
Amend release 0.6.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,6 @@ jobs:
     - uses: actions/checkout@v1
     - name: Publish Releases
       uses: thefrontside/actions/synchronize-with-npm@v1.3
-      with:
-        NPM_PUBLISH: npm run pack:publish
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 * fix bug where operations that returned `null` was causing effection
   to crash: https://github.com/thefrontside/effection.js/pull/98
+* `effection` is now compiled with microbundle instead of
+  pika. https://github.com/thefrontside/effection.js/pull/100
 
 ## [0.6.0] - 2020-04-15
 

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -14,7 +14,6 @@
   "scripts": {
     "lint": "echo [skip @effection/events]",
     "test": "mocha -r ts-node/register test/**/*.test.ts",
-    "pack:publish": "npm publish $*",
     "prepack": "tsc --outdir dist --project tsconfig.dist.json --declaration --sourcemap --module commonjs",
     "mocha": "mocha -r ts-node/register"
   },

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -11,7 +11,6 @@
   "scripts": {
     "lint": "echo [skip @effection/node]",
     "test": "echo '[no-tests @effection/node]'",
-    "pack:publish": "npm publish $*",
     "prepack": "tsc --outdir dist --project tsconfig.dist.json --declaration --sourcemap --module commonjs"
   },
   "devDependencies": {


### PR DESCRIPTION
Release 0.6.1 failed because pack publish script were removed after the move to microbundle. This goes all in by removing custom pack/publish scripts and just letting the normal NPM scripts do their work (where publish calls pack).