### PR TITLE
Reference types/index.d.ts from its source

### DIFF
--- a/packages/effection/package.json
+++ b/packages/effection/package.json
@@ -6,7 +6,7 @@
   "author": "Charles Lowell <cowboyd@frontside.io>",
   "license": "MIT",
   "private": false,
-  "types": "index.d.ts",
+  "types": "types/index.d.ts",
   "source": "src/index.js",
   "main": "dist/effection.js",
   "module": "dist/effection.module.js",


### PR DESCRIPTION
In order to make our dslint config work, everything needs to be in the`types/` directory. We were copying our `index.d.ts` using a pika plugin. However, we're not doing pika anymore, and so we have to just update package.json to reference the types directly.