### PR TITLE
Use yarn for prepacking and publishing

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -12,7 +12,10 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Publish PR Preview
-      uses: thefrontside/actions/publish-pr-preview@v1.2
+      uses: thefrontside/actions/publish-pr-preview@v1.4
+      with:
+        before_all: yarn prepack
+        npm_publish: yarn publish
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         NPM_TOKEN:  ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,10 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Publish Releases
-      uses: thefrontside/actions/synchronize-with-npm@v1.3
+      uses: thefrontside/actions/synchronize-with-npm@v1.6
+      with:
+        before_all: yarn prepack
+        npm_publish: yarn publish
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
Motivation
-----------
We wer using yarn for install and npm for publishing. Also, now that we have the node package which will depend on effection events, it's important that all interfaces are built in dependency order according to the root package.json

Approach
----------
This normalizes and upgrades the release and preview workflows, while adding a before_all hook to both to run a prepack on the entire repo.